### PR TITLE
Improve route attributes

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.20" />
+    <option name="version" value="2.0.21" />
   </component>
 </project>

--- a/benchmarks/src/jmh/kotlin/kotlet/InterceptorBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/kotlet/InterceptorBenchmark.kt
@@ -3,6 +3,8 @@ package kotlet
 import io.mockk.mockk
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import kotlet.attributes.RouteAttributes
+import kotlet.attributes.emptyRouteAttributes
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
@@ -13,6 +15,7 @@ private val EMPTY_CALL = object : HttpCall {
     override val rawRequest: HttpServletRequest = mockk()
     override val rawResponse: HttpServletResponse = mockk()
     override val parameters: Map<String, String> = emptyMap()
+    override val attributes: RouteAttributes = emptyRouteAttributes()
 }
 
 object SimpleInterceptor : Interceptor {

--- a/core/src/main/kotlin/kotlet/HttpCall.kt
+++ b/core/src/main/kotlin/kotlet/HttpCall.kt
@@ -2,6 +2,7 @@ package kotlet
 
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import kotlet.attributes.RouteAttributes
 import java.io.InputStream
 
 /**
@@ -32,6 +33,11 @@ interface HttpCall {
      * Parameters extracted from the route path.
      */
     val parameters: Map<String, String>
+
+    /**
+     * Attributes of the route.
+     */
+    val attributes: RouteAttributes
 
     /**
      * HTTP status code of the response.
@@ -89,5 +95,6 @@ internal data class HttpCallImpl(
     override val routePath: String,
     override val rawRequest: HttpServletRequest,
     override val rawResponse: HttpServletResponse,
-    override val parameters: Map<String, String>
+    override val parameters: Map<String, String>,
+    override val attributes: RouteAttributes,
 ) : HttpCall

--- a/core/src/main/kotlin/kotlet/Route.kt
+++ b/core/src/main/kotlin/kotlet/Route.kt
@@ -1,5 +1,7 @@
 package kotlet
 
+import kotlet.attributes.RouteAttributes
+
 /**
  * Route configuration.
  * Contains a route path and a list of handlers for different HTTP methods.
@@ -9,6 +11,11 @@ internal data class Route(
      * Route path.
      */
     val path: String,
+
+    /**
+     * Route attributes.
+     */
+    val attributes: Map<HttpMethod, RouteAttributes>,
 
     /**
      * Link to the global interceptors.

--- a/core/src/main/kotlin/kotlet/RouteHandler.kt
+++ b/core/src/main/kotlin/kotlet/RouteHandler.kt
@@ -28,6 +28,9 @@ internal data class RouteHandler(
                         it.settings.interceptors,
                         it.handler
                     )
+                },
+                attributes = handlers.associate {
+                    it.method to it.settings.attributes
                 }
             )
         }

--- a/core/src/main/kotlin/kotlet/RoutingServlet.kt
+++ b/core/src/main/kotlin/kotlet/RoutingServlet.kt
@@ -3,6 +3,7 @@ package kotlet
 import jakarta.servlet.http.HttpServlet
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import kotlet.attributes.emptyRouteAttributes
 
 /**
  * Servlet that handles all requests based on the provided routings.
@@ -22,12 +23,15 @@ internal class RoutingServlet(
             val httpMethod = HttpMethod.parse(request.method)
                 ?: return errorsHandler.methodNotFound(request, response)
 
+            val attributes = route.attributes[httpMethod] ?: emptyRouteAttributes()
+
             val httpCall = HttpCallImpl(
                 httpMethod = httpMethod,
                 routePath = route.path,
                 rawRequest = request,
                 rawResponse = response,
-                parameters = parameters
+                parameters = parameters,
+                attributes = attributes,
             )
 
             route.handler(httpCall)

--- a/core/src/main/kotlin/kotlet/attributes/RouteAttributes.kt
+++ b/core/src/main/kotlin/kotlet/attributes/RouteAttributes.kt
@@ -18,5 +18,14 @@ interface RouteAttributes {
      * Gets the attribute value for the specified key.
      */
     operator fun <T : Any> get(key: RouteAttribute<T>): T?
+}
 
+/**
+ * Returns an empty [RouteAttributes] instance.
+ */
+fun emptyRouteAttributes(): RouteAttributes = EmptyRouteAttributes
+
+private object EmptyRouteAttributes : RouteAttributes {
+    override fun <T : Any> containsKey(key: RouteAttribute<T>): Boolean = false
+    override fun <T : Any> get(key: RouteAttribute<T>): T? = null
 }

--- a/core/src/test/kotlin/kotlet/OneRouteMatcherUnitTest.kt
+++ b/core/src/test/kotlin/kotlet/OneRouteMatcherUnitTest.kt
@@ -13,7 +13,7 @@ internal class OneRouteMatcherUnitTest {
 
     @Test
     fun testStaticMatch() {
-        val route = Route("/first/second", emptyList(), emptyMap())
+        val route = Route("/first/second", emptyMap(), emptyList(), emptyMap())
         val selectors = RouteHelpers.prepareSelectorsList(route)
 
         val matcher = OneRouteMatcher(route, selectors)
@@ -35,7 +35,7 @@ internal class OneRouteMatcherUnitTest {
 
     @Test
     fun testRouteParamMatch() {
-        val route = Route("/first/{userId}/second/{fileId}", emptyList(), emptyMap())
+        val route = Route("/first/{userId}/second/{fileId}", emptyMap(), emptyList(), emptyMap())
         val selectors = RouteHelpers.prepareSelectorsList(route)
 
         val matcher = OneRouteMatcher(route, selectors)
@@ -57,7 +57,7 @@ internal class OneRouteMatcherUnitTest {
 
     @Test
     fun testOptionalRouteParamMatch() {
-        val route = Route("/first/{userId}/second/{fileId?}", emptyList(), emptyMap())
+        val route = Route("/first/{userId}/second/{fileId?}", emptyMap(), emptyList(), emptyMap())
         val selectors = RouteHelpers.prepareSelectorsList(route)
 
         val matcher = OneRouteMatcher(route, selectors)
@@ -84,7 +84,7 @@ internal class OneRouteMatcherUnitTest {
 
     @Test
     fun testWildcardMatch_MiddlePosition() {
-        val route = Route("/first/*/second", emptyList(), emptyMap())
+        val route = Route("/first/*/second", emptyMap(), emptyList(), emptyMap())
         val selectors = RouteHelpers.prepareSelectorsList(route)
 
         val matcher = OneRouteMatcher(route, selectors)
@@ -106,7 +106,7 @@ internal class OneRouteMatcherUnitTest {
 
     @Test
     fun testWildcardMatch_TailPosition() {
-        val route = Route("/first/*", emptyList(), emptyMap())
+        val route = Route("/first/*", emptyMap(), emptyList(), emptyMap())
         val selectors = RouteHelpers.prepareSelectorsList(route)
 
         val matcher = OneRouteMatcher(route, selectors)
@@ -128,7 +128,7 @@ internal class OneRouteMatcherUnitTest {
 
     @Test
     fun testTailMatch() {
-        val route = Route("/first/{...}", emptyList(), emptyMap())
+        val route = Route("/first/{...}", emptyMap(), emptyList(), emptyMap())
         val selectors = RouteHelpers.prepareSelectorsList(route)
 
         val matcher = OneRouteMatcher(route, selectors)

--- a/core/src/test/kotlin/kotlet/RouteHelpersUnitTest.kt
+++ b/core/src/test/kotlin/kotlet/RouteHelpersUnitTest.kt
@@ -14,7 +14,7 @@ internal class RouteHelpersUnitTest {
 
     @Test
     fun testStaticPath() {
-        val route = Route("/first/second", emptyList(), emptyMap())
+        val route = Route("/first/second", emptyMap(), emptyList(), emptyMap())
         val selectors = RouteHelpers.prepareSelectorsList(route)
 
         assertEquals(2, selectors.size)
@@ -32,7 +32,7 @@ internal class RouteHelpersUnitTest {
 
     @Test
     fun testWildcardPath() {
-        val route = Route("/first/*/second/*", emptyList(), emptyMap())
+        val route = Route("/first/*/second/*", emptyMap(), emptyList(), emptyMap())
         val selectors = RouteHelpers.prepareSelectorsList(route)
 
         assertEquals(4, selectors.size)
@@ -58,7 +58,7 @@ internal class RouteHelpersUnitTest {
 
     @Test
     fun testParametrizedPath() {
-        val route = Route("/first/{userId}/second", emptyList(), emptyMap())
+        val route = Route("/first/{userId}/second", emptyMap(), emptyList(), emptyMap())
         val selectors = RouteHelpers.prepareSelectorsList(route)
 
         assertEquals(3, selectors.size)
@@ -81,7 +81,7 @@ internal class RouteHelpersUnitTest {
 
     @Test
     fun testOptionalParametrizedPath() {
-        val route = Route("/first/second/{userId?}", emptyList(), emptyMap())
+        val route = Route("/first/second/{userId?}", emptyMap(), emptyList(), emptyMap())
         val selectors = RouteHelpers.prepareSelectorsList(route)
 
         assertEquals(3, selectors.size)
@@ -104,7 +104,7 @@ internal class RouteHelpersUnitTest {
 
     @Test
     fun testTailPath() {
-        val route = Route("/first/{...}", emptyList(), emptyMap())
+        val route = Route("/first/{...}", emptyMap(), emptyList(), emptyMap())
         val selectors = RouteHelpers.prepareSelectorsList(route)
 
         assertEquals(2, selectors.size)
@@ -121,7 +121,7 @@ internal class RouteHelpersUnitTest {
 
     @Test
     fun testComplexPathWithTail() {
-        val route = Route("/first/{id}/second/*/{...}", emptyList(), emptyMap())
+        val route = Route("/first/{id}/second/*/{...}", emptyMap(), emptyList(), emptyMap())
         val selectors = RouteHelpers.prepareSelectorsList(route)
 
         assertEquals(5, selectors.size)
@@ -152,7 +152,7 @@ internal class RouteHelpersUnitTest {
 
     @Test
     fun testComplexPathWithOptional() {
-        val route = Route("/first/{id}/second/*/{otherId?}", emptyList(), emptyMap())
+        val route = Route("/first/{id}/second/*/{otherId?}", emptyMap(), emptyList(), emptyMap())
         val selectors = RouteHelpers.prepareSelectorsList(route)
 
         assertEquals(5, selectors.size)
@@ -186,35 +186,35 @@ internal class RouteHelpersUnitTest {
     fun testCheckSelectors() {
         // check double Tails
         assertFailsWith(IllegalArgumentException::class) {
-            val route = Route("/first/{...}/{...}", emptyList(), emptyMap())
+            val route = Route("/first/{...}/{...}", emptyMap(), emptyList(), emptyMap())
             val selectors = RouteHelpers.prepareSelectorsList(route)
             RouteHelpers.checkSelectorsList(route.path, selectors)
         }
 
         // check double optionals
         assertFailsWith(IllegalArgumentException::class) {
-            val route = Route("/first/{a?}/{b?}", emptyList(), emptyMap())
+            val route = Route("/first/{a?}/{b?}", emptyMap(), emptyList(), emptyMap())
             val selectors = RouteHelpers.prepareSelectorsList(route)
             RouteHelpers.checkSelectorsList(route.path, selectors)
         }
 
         // check Tail in the last position
         assertFailsWith(IllegalArgumentException::class) {
-            val route = Route("/first/{...}/second", emptyList(), emptyMap())
+            val route = Route("/first/{...}/second", emptyMap(), emptyList(), emptyMap())
             val selectors = RouteHelpers.prepareSelectorsList(route)
             RouteHelpers.checkSelectorsList(route.path, selectors)
         }
 
         // check optional in the last position
         assertFailsWith(IllegalArgumentException::class) {
-            val route = Route("/first/{a?}/second", emptyList(), emptyMap())
+            val route = Route("/first/{a?}/second", emptyMap(), emptyList(), emptyMap())
             val selectors = RouteHelpers.prepareSelectorsList(route)
             RouteHelpers.checkSelectorsList(route.path, selectors)
         }
 
         // check repeated param names
         assertFailsWith(IllegalArgumentException::class) {
-            val route = Route("/first/{id}/second/{id}", emptyList(), emptyMap())
+            val route = Route("/first/{id}/second/{id}", emptyMap(), emptyList(), emptyMap())
             val selectors = RouteHelpers.prepareSelectorsList(route)
             RouteHelpers.checkSelectorsList(route.path, selectors)
         }

--- a/mocks/src/main/kotlin/kotlet/mocks/http/MockHttpCall.kt
+++ b/mocks/src/main/kotlin/kotlet/mocks/http/MockHttpCall.kt
@@ -6,6 +6,8 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import kotlet.HttpCall
 import kotlet.HttpMethod
+import kotlet.attributes.RouteAttributes
+import kotlet.attributes.emptyRouteAttributes
 import java.io.ByteArrayOutputStream
 import java.util.Collections
 import java.util.Enumeration
@@ -27,7 +29,7 @@ class MockHttpCall(
     override val parameters: Map<String, String> = emptyMap()
     override val rawRequest: HttpServletRequest
     override val rawResponse: HttpServletResponse
-
+    override val attributes: RouteAttributes = emptyRouteAttributes()
 
     /**
      * The response data as a [ByteArray].

--- a/sample/src/main/kotlin/SetHeaderInterceptor.kt
+++ b/sample/src/main/kotlin/SetHeaderInterceptor.kt
@@ -3,7 +3,7 @@ import kotlet.HttpCall
 import kotlet.Interceptor
 
 /**
- * Example of simple interceptor
+ * Example of simple interceptor that sets a header to the response
  */
 data class SetHeaderInterceptor(
     private val headerName: String,


### PR DESCRIPTION
This pull request introduces the concept of `RouteAttributes` to the `kotlet` package, which enhances the routing capabilities by allowing routes to have associated attributes. The changes span across multiple files, including core implementation, benchmarks, tests, and mock classes.

Key changes include:

### Core Implementation Enhancements:
* Added `RouteAttributes` to the `HttpCall` interface and its implementations (`HttpCall.kt`). [[1]](diffhunk://#diff-1930efcbcbfa79b4d3b359fd44f62ebf3e18f90aa0aae6aaf1d7f792e4d05cd1R37-R41) [[2]](diffhunk://#diff-1930efcbcbfa79b4d3b359fd44f62ebf3e18f90aa0aae6aaf1d7f792e4d05cd1L92-R99)
* Introduced `RouteAttributes` to the `Route` class and its handler (`Route.kt`, `RouteHandler.kt`). [[1]](diffhunk://#diff-c5885b0da6b20dfddfcb83f0471289bc482bb79f37797634edecbdcf4204003bR15-R19) [[2]](diffhunk://#diff-de1528e55b5c9a849d98426f5e5e307ae2a2967081655a48ebc05d7e5fc19960R31-R33)
* Created a utility function `emptyRouteAttributes` to provide an empty `RouteAttributes` instance (`RouteAttributes.kt`).

### Benchmark Updates:
* Updated `InterceptorBenchmark.kt` to include `RouteAttributes` in the `HttpCall` mock (`InterceptorBenchmark.kt`).

### Test Adjustments:
* Modified unit tests to accommodate the new `RouteAttributes` parameter in the `Route` constructor (`OneRouteMatcherUnitTest.kt`, `RouteHelpersUnitTest.kt`). [[1]](diffhunk://#diff-7238370f76bb5d689b6badae219d4e8cd356c9e50b2169b99d38365b7d40b7ffL16-R16) [[2]](diffhunk://#diff-bc22efcf8b1114c5d772f0187864fedc8769430847c847d6d0caa1eb6a79051fL17-R17)

### Mock Class Changes:
* Updated `MockHttpCall` to implement the new `RouteAttributes` property (`MockHttpCall.kt`).