### PR TITLE
Publish v2

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,9 +4,8 @@
 name: Gradle Publish
 
 on:
-  push:
-    tags:
-      - 'v*'  # Invoke this workflow on all tags that start with 'v'
+  release:
+    types: [created]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,7 @@
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.report.ReportMergeTask
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
 import java.net.URI
 
 group = "io.github.turchenkoalex"
@@ -111,6 +113,23 @@ subprojects {
     java {
         withJavadocJar()
         withSourcesJar()
+    }
+
+    // Unit tests settings
+    tasks.withType<Test> {
+        // enable parallel tests execution
+        systemProperties["junit.jupiter.execution.parallel.enabled"] = true
+        systemProperties["junit.jupiter.execution.parallel.mode.default"] = "concurrent"
+
+        // JUnit settings
+        useJUnitPlatform {
+            enableAssertions = true
+            testLogging {
+                exceptionFormat = TestExceptionFormat.FULL
+                events = setOf(TestLogEvent.FAILED, TestLogEvent.SKIPPED)
+                showStandardStreams = false
+            }
+        }
     }
 
     configure<PublishingExtension> {

--- a/json/src/main/kotlin/kotlet/json/Serializer.kt
+++ b/json/src/main/kotlin/kotlet/json/Serializer.kt
@@ -1,5 +1,6 @@
 package kotlet.json
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
@@ -9,6 +10,7 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.util.concurrent.ConcurrentHashMap
 
+@OptIn(ExperimentalSerializationApi::class)
 object Serializer {
     private val kotlinSerializersCache = ConcurrentHashMap<Class<*>, KSerializer<*>>()
 


### PR DESCRIPTION
This pull request includes changes to the Gradle publish workflow and updates to the `Serializer` class in the `kotlet.json` package. The most important changes are summarized below:

Workflow improvements:

* [`.github/workflows/publish.yaml`](diffhunk://#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388caL7-R8): Modified the workflow to trigger on release creation instead of on tags that start with 'v'.

Code updates:

* [`json/src/main/kotlin/kotlet/json/Serializer.kt`](diffhunk://#diff-1fe368d7f6bce949cfcc325395d59d22929dc07d62782b0cb24902374b097d06R3): Added import for `ExperimentalSerializationApi` and annotated the `Serializer` object with `@OptIn(ExperimentalSerializationApi::class)`. [[1]](diffhunk://#diff-1fe368d7f6bce949cfcc325395d59d22929dc07d62782b0cb24902374b097d06R3) [[2]](diffhunk://#diff-1fe368d7f6bce949cfcc325395d59d22929dc07d62782b0cb24902374b097d06R13)