### PR TITLE
Release on merge PR

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,8 +4,9 @@
 name: Gradle Publish
 
 on:
-  release:
-    types: [created]
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -37,13 +38,10 @@ jobs:
           java-version: '${{ env.JDK_VERSION }}'
           cache: 'gradle'
 
-      - name: Build with Gradle
-        run: gradle build -Prelease.useLastTag=true
-
       # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
       # the publishing section of your build.gradle
       - name: Publish client to GitHub Packages
-        run: gradle publish -Prelease.useLastTag=true
+        run: gradle final
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -146,13 +146,46 @@ subprojects {
 
         publications {
             register<MavenPublication>("gpr") {
+                from(components["java"])
+
                 version = sanitizeVersion()
                 groupId = "io.github.turchenkoalex"
                 artifactId = "kotlet-${project.name}"
-                from(components["java"])
+
+                pom {
+                    name.set("kotlet-${project.name}")
+                    description.set("Kotlet ${project.name} module")
+                    url.set("https://github.com/turchenkoalex/kotlet")
+
+                    licenses {
+                        license {
+                            name.set("The Apache License, Version 2.0")
+                            url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id.set("turchenkoalex")
+                            name.set("Aleksandr Turchenko")
+                        }
+
+                        scm {
+                            connection.set("scm:git:git://github.com/turchenkoalex/kotlet.git")
+                            url.set("https://github.com/turchenkoalex/kotlet")
+                            developerConnection.set("scm:git:ssh://github.com:turchenkoalex/kotlet.git")
+                        }
+                    }
+                }
+
             }
         }
     }
+
+
+    rootProject.tasks["final"].dependsOn(tasks.getByName("publish"))
+
+    rootProject.tasks["devSnapshot"].dependsOn(tasks.getByName("publish"))
 }
 
 // We want to change SNAPSHOT versions format from:
@@ -190,4 +223,39 @@ object ProjectEnvs {
 
     val githubHeadRef: String?
         get() = System.getenv("GITHUB_HEAD_REF")
+}
+
+tasks.register("printFinalReleaseNote") {
+    doLast {
+        printReleaseNote(
+            groupId = "io.github.turchenkoalex",
+            artifactId = project.name,
+            sanitizedVersion = project.sanitizeVersion()
+        )
+    }
+    dependsOn(tasks.getByName("final"))
+}
+
+tasks.register("printDevSnapshotReleaseNote") {
+    doLast {
+        printReleaseNote(
+            groupId = "io.github.turchenkoalex",
+            artifactId = project.name,
+            sanitizedVersion = project.sanitizeVersion()
+        )
+    }
+    dependsOn(tasks.getByName("devSnapshot"))
+}
+
+fun printReleaseNote(groupId: String, artifactId: String, sanitizedVersion: String) {
+    println()
+    println("========================================================")
+    println()
+    println("New RELEASE artifact version were published:")
+    println("	groupId: $groupId")
+    println("	artifactId: $artifactId")
+    println("	version: $sanitizedVersion")
+    println()
+    println("========================================================")
+    println()
 }


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/publish.yaml` file to modify the GitHub Actions workflow for publishing with Gradle. The changes adjust the event that triggers the workflow and update the commands used for building and publishing.

Key changes:

* **Trigger event modification**:
  * Changed the workflow trigger from `release` event to `push` event on the `main` branch.

* **Build and publish commands update**:
  * Removed the `Build with Gradle` step.
  * Updated the `Publish client to GitHub Packages` step to use the `gradle final` command instead of `gradle publish -Prelease.useLastTag=true`.