### PR TITLE
Release on merge PR - v2

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - README.md
+      - 'docs/**'
 
 permissions:
   contents: write
@@ -14,20 +17,20 @@ env:
   GRADLE_OPTS: -Dorg.gradle.daemon=false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-push-to-main
   cancel-in-progress: true
 
 jobs:
   build:
     name: Build and Run Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Set up JDK ${{ env.JDK_VERSION }}
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'corretto'
           java-version: '${{ env.JDK_VERSION }}'
           cache: 'gradle'
       - name: Build and Run JMH benchmarks

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,9 +7,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - README.md
+      - 'docs/**'
+
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-push-to-main
   cancel-in-progress: true
 
 permissions:
@@ -23,25 +27,28 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
 
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
-        with:
-          fetch-tags: true
+
+      - name: Set up Git user
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: Set up JDK ${{ env.JDK_VERSION }}
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'corretto'
           java-version: '${{ env.JDK_VERSION }}'
           cache: 'gradle'
 
       # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
       # the publishing section of your build.gradle
       - name: Publish client to GitHub Packages
-        run: gradle final
+        run: gradle final printFinalReleaseNote
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,7 +1,7 @@
 name: verify
 on:
   pull_request:
-    path-ignore:
+    paths-ignore:
       - 'docs/**'
       - 'README.md'
 
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   test:
     name: Build and Run Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       checks: write
@@ -27,7 +27,7 @@ jobs:
       - name: Set up JDK ${{ env.JDK_VERSION }}
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'corretto'
           java-version: '${{ env.JDK_VERSION }}'
           cache: 'gradle'
       - name: Build and Run Tests


### PR DESCRIPTION
This pull request includes several updates to the GitHub Actions workflows to improve their efficiency and compatibility. The changes primarily focus on updating the environment settings, concurrency groups, and paths to be ignored for certain triggers.

### Workflow updates:

* [`.github/workflows/benchmark.yaml`](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930R7-R9): Added paths to be ignored for the `push` event, changed the concurrency group to `push-to-main`, updated the runner to `ubuntu-24.04-arm`, and switched the JDK distribution from 'adopt' to 'corretto'. [[1]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930R7-R9) [[2]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L17-R33)
* [`.github/workflows/publish.yaml`](diffhunk://#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388caR10-R16): Added paths to be ignored for the `push` event, changed the concurrency group to `push-to-main`, updated the runner to `ubuntu-24.04-arm`, added a step to set up the Git user, and switched the JDK distribution from 'adopt' to 'corretto'. [[1]](diffhunk://#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388caR10-R16) [[2]](diffhunk://#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388caL26-R51)
* [`.github/workflows/verify.yaml`](diffhunk://#diff-1440bd8668b126838d91c4736aa5d2dfe6429e97a2e0a45b1a0ac5562ab990ffL4-R4): Corrected the key from `path-ignore` to `paths-ignore`, updated the runner to `ubuntu-24.04-arm`, and switched the JDK distribution from 'adopt' to 'corretto'. [[1]](diffhunk://#diff-1440bd8668b126838d91c4736aa5d2dfe6429e97a2e0a45b1a0ac5562ab990ffL4-R4) [[2]](diffhunk://#diff-1440bd8668b126838d91c4736aa5d2dfe6429e97a2e0a45b1a0ac5562ab990ffL19-R19) [[3]](diffhunk://#diff-1440bd8668b126838d91c4736aa5d2dfe6429e97a2e0a45b1a0ac5562ab990ffL30-R30)