### PR TITLE
Release on merge - Add package build

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -1,9 +1,12 @@
 name: benchmark
+
 on:
-  pull_request:
-    path-ignore:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - README.md
       - 'docs/**'
-      - 'README.md'
 
 permissions:
   contents: write
@@ -14,26 +17,26 @@ env:
   GRADLE_OPTS: -Dorg.gradle.daemon=false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-push-to-main
   cancel-in-progress: true
 
 jobs:
   build:
     name: Build and Run Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Set up JDK ${{ env.JDK_VERSION }}
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'corretto'
           java-version: '${{ env.JDK_VERSION }}'
           cache: 'gradle'
       - name: Build and Run JMH benchmarks
         run: ./gradlew :benchmarks:jmh
       - name: JMH Benchmark Action
-        uses: kitlangton/jmh-benchmark-action@ea96a79ecacbec56b6bb17aafb90275bfbf26ebb
+        uses: kitlangton/jmh-benchmark-action@main
         with:
           jmh-output-path: benchmarks/build/reports/jmh/results.json
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,54 @@
+# This workflow will build a package using Gradle and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java#publishing-using-gradle
+
+name: Gradle Publish
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - README.md
+      - 'docs/**'
+
+
+concurrency:
+  group: ${{ github.workflow }}-push-to-main
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  JDK_VERSION: 21
+  GRADLE_OPTS: -Dorg.gradle.daemon=false
+
+jobs:
+  build:
+
+    runs-on: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Git user
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: Set up JDK ${{ env.JDK_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '${{ env.JDK_VERSION }}'
+          cache: 'gradle'
+
+      # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
+      # the publishing section of your build.gradle
+      - name: Publish client to GitHub Packages
+        run: ./gradlew final printFinalReleaseNote --parallel
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,7 +1,7 @@
 name: verify
 on:
   pull_request:
-    path-ignore:
+    paths-ignore:
       - 'docs/**'
       - 'README.md'
 
@@ -16,22 +16,23 @@ concurrency:
 jobs:
   test:
     name: Build and Run Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       checks: write
       pull-requests: write
+      packages: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Set up JDK ${{ env.JDK_VERSION }}
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'corretto'
           java-version: '${{ env.JDK_VERSION }}'
           cache: 'gradle'
       - name: Build and Run Tests
-        run: ./gradlew test koverXmlReport
+        run: ./gradlew test koverXmlReport --parallel
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v5
         if: success() || failure() # always run even if the previous step fails
@@ -47,7 +48,14 @@ jobs:
           min-coverage-overall: 50
           min-coverage-changed-files: 60
       - name: Coverage verify
-        run: ./gradlew koverVerify
+        run: ./gradlew koverVerify --parallel
+      # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
+      # the publishing section of your build.gradle
+      - name: Publish client to GitHub Packages
+        run: ./gradlew devSnapshot printDevSnapshotReleaseNote --parallel
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   detekt:
     name: Detekt
     runs-on: ubuntu-latest

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.1.0" />
+    <option name="version" value="2.1.10" />
   </component>
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,19 +1,41 @@
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.report.ReportMergeTask
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+import java.net.URI
 
 group = "io.github.turchenkoalex"
-version = "1.0-SNAPSHOT"
 
 plugins {
+    `java-library`
+    `maven-publish`
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlinx.serialization) apply false
     alias(libs.plugins.detekt)
     alias(libs.plugins.kover)
+    alias(libs.plugins.nebula.release)
 }
 
 allprojects {
     repositories {
         mavenCentral()
+    }
+
+    // Unit tests settings
+    tasks.withType<Test> {
+        // enable parallel tests execution
+        systemProperties["junit.jupiter.execution.parallel.enabled"] = true
+        systemProperties["junit.jupiter.execution.parallel.mode.default"] = "concurrent"
+
+        // JUnit settings
+        useJUnitPlatform {
+            enableAssertions = true
+            testLogging {
+                exceptionFormat = TestExceptionFormat.FULL
+                events = setOf(TestLogEvent.FAILED, TestLogEvent.SKIPPED)
+                showStandardStreams = false
+            }
+        }
     }
 }
 
@@ -52,6 +74,7 @@ subprojects {
     }
 }
 
+// Coverage configuration
 val coverageExclusions = setOf(
     "benchmarks",
     "mocks",
@@ -59,22 +82,166 @@ val coverageExclusions = setOf(
 )
 
 subprojects {
-    if (this.name !in coverageExclusions) {
-        apply(plugin = "org.jetbrains.kotlinx.kover")
+    if (this.name in coverageExclusions) {
+        return@subprojects
+    }
 
-        // register kover for generating merged report from all subprojects
-        rootProject.dependencies {
-            kover(project)
-        }
+    apply(plugin = "org.jetbrains.kotlinx.kover")
 
-        kover {
-            reports {
-                verify {
-                    rule("Minimal line coverage rate in percents") {
-                        minBound(40)
-                    }
+    // register kover for generating merged report from all subprojects
+    rootProject.dependencies {
+        kover(project)
+    }
+
+    kover {
+        reports {
+            verify {
+                rule("Minimal line coverage rate in percents") {
+                    minBound(40)
                 }
             }
         }
     }
+}
+
+// Publishing configuration
+val publishPackages = setOf(
+    "core",
+    "cors",
+    "json",
+    "jwt",
+    "metrics",
+    "openapi",
+    "swagger-ui",
+    "tracing",
+    "typesafe",
+)
+
+subprojects {
+    if (this.name !in publishPackages) {
+        return@subprojects
+    }
+
+    apply(plugin = "java-library")
+    apply(plugin = "maven-publish")
+
+    version = sanitizeVersion()
+
+    java {
+        withJavadocJar()
+        withSourcesJar()
+    }
+
+    configure<PublishingExtension> {
+        repositories {
+            maven {
+                name = "GitHubPackages"
+                url = URI("https://maven.pkg.github.com/turchenkoalex/kotlet")
+                credentials {
+                    username = ProjectEnvs.githubActor
+                    password = ProjectEnvs.githubToken
+                }
+            }
+        }
+
+        publications {
+            register<MavenPublication>("gpr") {
+                from(components["java"])
+
+                version = sanitizeVersion()
+                groupId = "io.github.turchenkoalex"
+                artifactId = "kotlet-${project.name}"
+
+                pom {
+                    name.set("kotlet-${project.name}")
+                    description.set("Kotlet ${project.name} module")
+                    url.set("https://github.com/turchenkoalex/kotlet")
+
+                    licenses {
+                        license {
+                            name.set("The Apache License, Version 2.0")
+                            url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            id.set("turchenkoalex")
+                            name.set("Aleksandr Turchenko")
+                        }
+
+                        scm {
+                            connection.set("scm:git:git://github.com/turchenkoalex/kotlet.git")
+                            url.set("https://github.com/turchenkoalex/kotlet")
+                            developerConnection.set("scm:git:ssh://github.com:turchenkoalex/kotlet.git")
+                        }
+                    }
+                }
+
+            }
+        }
+    }
+
+
+    rootProject.tasks["final"].dependsOn(tasks.getByName("publish"))
+
+    rootProject.tasks["devSnapshot"].dependsOn(tasks.getByName("publish"))
+}
+
+// We want to change SNAPSHOT versions format from:
+// 		<major>.<minor>.<patch>-dev.#+<branchname>.<hash> (local branch)
+// 		<major>.<minor>.<patch>-dev.#+<hash> (github pull request)
+// to:
+// 		<major>.<minor>.<patch>-SNAPSHOT
+fun Project.sanitizeVersion(): String {
+    val version = version.toString()
+    return if (project.isSnapshotVersion()) {
+        // replace -dev.#+<branchname>.<hash> with -SNAPSHOT
+        version.replace(Regex("-dev\\..+$"), "-dev-SNAPSHOT")
+    } else {
+        version
+    }
+}
+
+fun Project.isSnapshotVersion() = version.toString().contains("-dev")
+
+object ProjectEnvs {
+    val githubActor: String?
+        get() = System.getenv("GITHUB_ACTOR")
+
+    val githubToken: String?
+        get() = System.getenv("GITHUB_TOKEN")
+}
+
+tasks.register("printFinalReleaseNote") {
+    doLast {
+        printReleaseNote()
+    }
+    dependsOn(tasks.getByName("final"))
+}
+
+tasks.register("printDevSnapshotReleaseNote") {
+    doLast {
+        printReleaseNote()
+    }
+    dependsOn(tasks.getByName("devSnapshot"))
+}
+
+fun printReleaseNote() {
+    val groupId = project.group
+    val sanitizedVersion = project.sanitizeVersion()
+
+    println()
+    println("========================================================")
+    println()
+    println("New artifacts were published:")
+    println("	groupId: $groupId")
+    println("	version: $sanitizedVersion")
+    println("	artifacts:")
+    publishPackages.sorted().forEach {
+        println("\t\t- kotlet-$it")
+    }
+    println()
+    println("========================================================")
+    println()
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,11 +7,12 @@ kotlin = "2.1.10"
 kotlinx-serialization = "1.8.0"
 kover = "0.9.1"
 mockk = "1.13.17"
+nebula = "20.2.0"
 opentelemetry = "1.48.0"
-opentelemetry-instrumentation-api = "2.13.0"
+opentelemetry-instrumentation-api = "2.14.0"
 opentelemetry-semconv = "1.30.0"
 prometheus = "1.3.6"
-swagger = "2.2.28"
+swagger = "2.2.29"
 
 [plugins]
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
@@ -19,6 +20,7 @@ jmh = { id = "me.champeau.jmh", version = "0.7.3" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
+nebula-release = { id = "com.netflix.nebula.release", version.ref = "nebula" }
 
 [libraries]
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/json/src/main/kotlin/kotlet/json/Serializer.kt
+++ b/json/src/main/kotlin/kotlet/json/Serializer.kt
@@ -1,5 +1,6 @@
 package kotlet.json
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
@@ -9,6 +10,7 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.util.concurrent.ConcurrentHashMap
 
+@OptIn(ExperimentalSerializationApi::class)
 object Serializer {
     private val kotlinSerializersCache = ConcurrentHashMap<Class<*>, KSerializer<*>>()
 


### PR DESCRIPTION
This pull request includes several updates to GitHub Actions workflows and dependencies, along with minor code adjustments. The most important changes involve modifying the workflows to use updated configurations and dependencies.

### Workflow Updates:

* [`.github/workflows/benchmark.yaml`](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930R2-L6): Changed the trigger from `pull_request` to `push` on the `main` branch, updated the runner to `ubuntu-24.04-arm`, and switched the JDK distribution to `corretto` [[1]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930R2-L6) [[2]](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930L17-R39).
* [`.github/workflows/publish.yaml`](diffhunk://#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388caR1-R54): Added a new workflow for publishing packages using Gradle, triggered by pushes to the `main` branch.
* [`.github/workflows/verify.yaml`](diffhunk://#diff-1440bd8668b126838d91c4736aa5d2dfe6429e97a2e0a45b1a0ac5562ab990ffL4-R4): Updated the runner to `ubuntu-24.04-arm` and switched the JDK distribution to `corretto` [[1]](diffhunk://#diff-1440bd8668b126838d91c4736aa5d2dfe6429e97a2e0a45b1a0ac5562ab990ffL4-R4) [[2]](diffhunk://#diff-1440bd8668b126838d91c4736aa5d2dfe6429e97a2e0a45b1a0ac5562ab990ffL19-R19) [[3]](diffhunk://#diff-1440bd8668b126838d91c4736aa5d2dfe6429e97a2e0a45b1a0ac5562ab990ffL30-R30).

### Dependency Updates:

* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR10-R23): Updated several dependencies, including Kotlin to `2.1.10` and swagger to `2.2.29`.
* [`gradle/wrapper/gradle-wrapper.properties`](diffhunk://#diff-40640fe1078ece83d7ea8fb67daacd77923a86d13447baf9769660b3b46f2eceL3-R3): Updated Gradle distribution to `8.13`.

### Code Adjustments:

* [`json/src/main/kotlin/kotlet/json/Serializer.kt`](diffhunk://#diff-1fe368d7f6bce949cfcc325395d59d22929dc07d62782b0cb24902374b097d06R3): Added an import for `ExperimentalSerializationApi` and annotated the `Serializer` object with `@OptIn` [[1]](diffhunk://#diff-1fe368d7f6bce949cfcc325395d59d22929dc07d62782b0cb24902374b097d06R3) [[2]](diffhunk://#diff-1fe368d7f6bce949cfcc325395d59d22929dc07d62782b0cb24902374b097d06R13).