### PR TITLE
Fix permissions for publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 env:


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/publish.yaml` file to update the permissions for the workflow.

Permissions update:

* [`.github/workflows/publish.yaml`](diffhunk://#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388caL20-R20): Changed the `contents` permission from `read` to `write` to allow the workflow to modify repository contents.