### PR TITLE
Fix tags for publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          fetch-tags: 'true'
 
       - name: Set up Git user
         run: |


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/publish.yaml` file. The change ensures that tags are fetched when checking out the code.

* [`.github/workflows/publish.yaml`](diffhunk://#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388caR35-R36): Added `fetch-tags: 'true'` to the `Checkout Code` step to ensure tags are fetched.