### PR TITLE
Fix tags for publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-tags: 'true'
+          fetch-depth: '0'
 
       - name: Set up Git user
         run: |


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/publish.yaml` file. The change modifies the `jobs` section to set the `fetch-depth` parameter to '0' when checking out the repository.