### PR TITLE
Update readme files

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -56,10 +56,12 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+
       - name: Update README files
-        uses: MathieuSoysal/file-updater-for-release@v1.0.3
-        with:
-          files: README.md cors/README.md json/README.md jwt/README.md metrics/README.md openapi/README.md swagger-ui/README.md tracing/README.md typesafe/README.md
+        shell: bash
+        run: |
+          NEW_VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
+          find . -name "README.md" -exec sed -Ei "s|io.github.turchenkoalex:kotlet-([a-zA-Z0-9_-]+):[0-9.]+|io.github.turchenkoalex:kotlet-\1:${NEW_VERSION}|g" {} +;
 
       - name: Push changes
         uses: EndBug/add-and-commit@v9


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/publish.yaml` file to update the method used for updating README files during the publish workflow. The most important change is the replacement of the `MathieuSoysal/file-updater-for-release` GitHub Action with a custom shell script to update README files with the new version.

Workflow changes:

* [`.github/workflows/publish.yaml`](diffhunk://#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388caR59-R64): Replaced the `MathieuSoysal/file-updater-for-release` GitHub Action with a custom shell script to update the version in `README.md` files.