### PR TITLE
Add PR instead direct push

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths-ignore:
       - README.md
+      - '**/README.md'
       - 'docs/**'
 
 permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,8 +14,16 @@ name: "CodeQL Advanced"
 on:
   push:
     branches: [ "main" ]
+    paths-ignore:
+      - README.md
+      - '**/README.md'
+      - 'docs/**'
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - README.md
+      - '**/README.md'
+      - 'docs/**'
   schedule:
     - cron: '24 8 * * 0'
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,8 +9,8 @@ on:
       - main
     paths-ignore:
       - README.md
+      - '**/README.md'
       - 'docs/**'
-
 
 concurrency:
   group: ${{ github.workflow }}-push-to-main
@@ -19,6 +19,7 @@ concurrency:
 permissions:
   contents: write
   packages: write
+  pull-requests: write
 
 env:
   JDK_VERSION: 21
@@ -56,17 +57,18 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-
       - name: Update README files
         shell: bash
         run: |
           NEW_VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
           find . -name "README.md" -exec sed -Ei "s|io.github.turchenkoalex:kotlet-([a-zA-Z0-9_-]+):[0-9.]+|io.github.turchenkoalex:kotlet-\1:${NEW_VERSION}|g" {} +;
 
-      - name: Push changes
-        uses: EndBug/add-and-commit@v9
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
         with:
-          committer_name: "${{ github.actor }}"
-          committer_email: "${{ github.actor }}@users.noreply.github.com"
-          add: .
-          message: 'Update version in README files'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update README dependencies to new version"
+          branch: update-readme
+          title: "Update README versions"
+          body: "This PR updates dependencies in README.md to new version."
+          base: main

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -2,8 +2,9 @@ name: verify
 on:
   pull_request:
     paths-ignore:
+      - README.md
+      - '**/README.md'
       - 'docs/**'
-      - 'README.md'
 
 env:
   JDK_VERSION: 21


### PR DESCRIPTION
This pull request includes several updates to the GitHub Actions workflows to optimize the handling of `README.md` files and improve the process for updating dependencies in these files. The most important changes include adding path ignore rules for `README.md` files, and modifying the publish workflow to create a pull request for README updates instead of directly pushing changes.

### Workflow optimizations:

* [`.github/workflows/benchmark.yaml`](diffhunk://#diff-05e6e31b7a98f5c219e73a9d7874ca00c15754129ff106552ef970240b509930R9): Added path ignore rules for `README.md` files and any README files in subdirectories.
* [`.github/workflows/codeql.yml`](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27R17-R26): Added path ignore rules for `README.md` files and any README files in subdirectories for both push and pull request events.
* [`.github/workflows/publish.yaml`](diffhunk://#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388caR12): Added path ignore rules for `README.md` files and any README files in subdirectories.
* [`.github/workflows/verify.yaml`](diffhunk://#diff-1440bd8668b126838d91c4736aa5d2dfe6429e97a2e0a45b1a0ac5562ab990ffR5-L6): Modified path ignore rules to include any README files in subdirectories.

### Dependency update process improvement:

* [`.github/workflows/publish.yaml`](diffhunk://#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388caL59-R74): Changed the workflow to create a pull request for README updates instead of directly pushing changes, using the `peter-evans/create-pull-request@v5` action.