### PR TITLE
Default pool for jetty

### DIFF
--- a/jetty/src/main/kotlin/kotlet/jetty/JettyBuilder.kt
+++ b/jetty/src/main/kotlin/kotlet/jetty/JettyBuilder.kt
@@ -27,6 +27,8 @@ class JettyBuilder internal constructor() {
 
     var errorsHandler: ErrorsHandler? = null
 
+    var gzipEnabled: Boolean = true
+
     internal fun build(routing: List<Routing>): Server {
         val servlet = Kotlet.servlet(routing, errorsHandler)
 
@@ -39,7 +41,11 @@ class JettyBuilder internal constructor() {
         val http2 = HTTP2CServerConnectionFactory()
 
         return Server(threadPool).apply {
-            handler = GzipHandler(servletHandler)
+            handler = if (gzipEnabled) {
+                GzipHandler(servletHandler)
+            } else {
+                servletHandler
+            }
 
             // HTTP
             addConnector(

--- a/jetty/src/main/kotlin/kotlet/jetty/JettyBuilder.kt
+++ b/jetty/src/main/kotlin/kotlet/jetty/JettyBuilder.kt
@@ -11,8 +11,8 @@ import org.eclipse.jetty.server.HttpConnectionFactory
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.ServerConnector
 import org.eclipse.jetty.server.handler.gzip.GzipHandler
+import org.eclipse.jetty.util.thread.QueuedThreadPool
 import org.eclipse.jetty.util.thread.ThreadPool
-import org.eclipse.jetty.util.thread.VirtualThreadPool
 
 class JettyBuilder internal constructor() {
     private val httpConfiguration = HttpConfiguration().apply {
@@ -23,7 +23,7 @@ class JettyBuilder internal constructor() {
 
     var port: Int = 80
 
-    var threadPool: ThreadPool = VirtualThreadPool()
+    var threadPool: ThreadPool = QueuedThreadPool()
 
     var errorsHandler: ErrorsHandler? = null
 


### PR DESCRIPTION
This pull request to `jetty/src/main/kotlin/kotlet/jetty/JettyBuilder.kt` includes changes to improve the configuration and flexibility of the Jetty server setup. The most important changes include replacing the `VirtualThreadPool` with `QueuedThreadPool`, adding a new `gzipEnabled` property, and modifying the handler setup to conditionally use `GzipHandler`.

Improvements to Jetty server configuration:

* Replaced `VirtualThreadPool` with `QueuedThreadPool` for the `threadPool` property in the `JettyBuilder` class.
* Added a new `gzipEnabled` property to the `JettyBuilder` class, allowing users to enable or disable Gzip compression.
* Modified the handler setup to conditionally use `GzipHandler` based on the value of the `gzipEnabled` property.

Imports update:

* Removed import for `VirtualThreadPool` and added import for `QueuedThreadPool`.