### PR TITLE
Rename metric label from path to route_path

### DIFF
--- a/metrics/src/main/kotlin/kotlet/prometheus/PrometheusMetricsCollector.kt
+++ b/metrics/src/main/kotlin/kotlet/prometheus/PrometheusMetricsCollector.kt
@@ -30,7 +30,7 @@ class PrometheusMetricsCollector(
     private val counter = Counter.builder()
         .name("kotlet_http_requests_total")
         .help("Total number of HTTP requests")
-        .labelNames("method", "path", "status")
+        .labelNames("method", "route_path", "status")
         .register(registry)
 
     private val summary = Summary.builder()
@@ -41,7 +41,7 @@ class PrometheusMetricsCollector(
         .quantile(0.9, 0.01)
         .quantile(0.95, 0.005)
         .quantile(0.99, 0.001)
-        .labelNames("method", "path", "status")
+        .labelNames("method", "route_path", "status")
         .register(registry)
 }
 

--- a/metrics/src/test/kotlin/kotlet/metrics/MetricsScrapeUnitTest.kt
+++ b/metrics/src/test/kotlin/kotlet/metrics/MetricsScrapeUnitTest.kt
@@ -45,15 +45,15 @@ class MetricsScrapeUnitTest {
         val expected = """
             # HELP kotlet_http_requests_total Total number of HTTP requests
             # TYPE kotlet_http_requests_total counter
-            kotlet_http_requests_total{method="GET",path="/",status="200"} 1.0
+            kotlet_http_requests_total{method="GET",route_path="/",status="200"} 1.0
             # HELP kotlet_http_requests_duration_seconds Duration of HTTP requests in seconds
             # TYPE kotlet_http_requests_duration_seconds summary
-            kotlet_http_requests_duration_seconds{method="GET",path="/",status="200",quantile="0.5"} 0.0
-            kotlet_http_requests_duration_seconds{method="GET",path="/",status="200",quantile="0.9"} 0.0
-            kotlet_http_requests_duration_seconds{method="GET",path="/",status="200",quantile="0.95"} 0.0
-            kotlet_http_requests_duration_seconds{method="GET",path="/",status="200",quantile="0.99"} 0.0
-            kotlet_http_requests_duration_seconds_count{method="GET",path="/",status="200"} 1
-            kotlet_http_requests_duration_seconds_sum{method="GET",path="/",status="200"} 0.0
+            kotlet_http_requests_duration_seconds{method="GET",route_path="/",status="200",quantile="0.5"} 0.0
+            kotlet_http_requests_duration_seconds{method="GET",route_path="/",status="200",quantile="0.9"} 0.0
+            kotlet_http_requests_duration_seconds{method="GET",route_path="/",status="200",quantile="0.95"} 0.0
+            kotlet_http_requests_duration_seconds{method="GET",route_path="/",status="200",quantile="0.99"} 0.0
+            kotlet_http_requests_duration_seconds_count{method="GET",route_path="/",status="200"} 1
+            kotlet_http_requests_duration_seconds_sum{method="GET",route_path="/",status="200"} 0.0
 
             """.trimIndent()
 

--- a/metrics/src/test/kotlin/kotlet/prometheus/PrometheusMetricsCollectorUnitTest.kt
+++ b/metrics/src/test/kotlin/kotlet/prometheus/PrometheusMetricsCollectorUnitTest.kt
@@ -61,7 +61,7 @@ class PrometheusMetricsCollectorUnitTest {
         assertEquals(1.0, point.value)
         assertEquals(3, point.labels.size())
         assertEquals("GET", point.labels.get("method"))
-        assertEquals("/", point.labels.get("path"))
+        assertEquals("/", point.labels.get("route_path"))
         assertEquals("200", point.labels.get("status"))
     }
 
@@ -98,7 +98,7 @@ class PrometheusMetricsCollectorUnitTest {
         assertEquals(0.99, point.quantiles.get(3).quantile)
         assertEquals(5.0, point.quantiles.get(3).value)
         assertEquals("POST", point.labels.get("method"))
-        assertEquals("/test", point.labels.get("path"))
+        assertEquals("/test", point.labels.get("route_path"))
         assertEquals("400", point.labels.get("status"))
     }
 


### PR DESCRIPTION
This pull request includes changes to the `PrometheusMetricsCollector` class in the `metrics/src/main/kotlin/kotlet/prometheus/PrometheusMetricsCollector.kt` file. The changes focus on updating the label names used in metrics collection.

Changes to metrics collection:

* [`metrics/src/main/kotlin/kotlet/prometheus/PrometheusMetricsCollector.kt`](diffhunk://#diff-5d2612f8abc53c5000356698f89a4d3487ee049281eba3dee601e275490207b3L33-R33): Updated the `labelNames` from "path" to "route_path" for both the `Counter` and `Summary` metrics. [[1]](diffhunk://#diff-5d2612f8abc53c5000356698f89a4d3487ee049281eba3dee601e275490207b3L33-R33) [[2]](diffhunk://#diff-5d2612f8abc53c5000356698f89a4d3487ee049281eba3dee601e275490207b3L44-R44)