### PR TITLE
Sonatype

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -52,10 +52,14 @@ jobs:
       # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
       # the publishing section of your build.gradle
       - name: Publish client to GitHub Packages
-        run: ./gradlew final printFinalReleaseNote --parallel
+        run: ./gradlew final publishToSonatype closeAndReleaseStagingRepository printFinalReleaseNote
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
 
       - name: Update README files
         shell: bash

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -53,7 +53,7 @@ jobs:
       # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
       # the publishing section of your build.gradle
       - name: Publish client to GitHub Packages
-        run: ./gradlew devSnapshot printDevSnapshotReleaseNote --parallel
+        run: ./gradlew devSnapshot printDevSnapshotReleaseNote
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -52,11 +52,11 @@ jobs:
         run: ./gradlew koverVerify --parallel
       # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
       # the publishing section of your build.gradle
-      - name: Publish client to GitHub Packages
-        run: ./gradlew devSnapshot printDevSnapshotReleaseNote
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      - name: Publish client to GitHub Packages
+#        run: ./gradlew devSnapshot printDevSnapshotReleaseNote
+#        env:
+#          GITHUB_ACTOR: ${{ github.actor }}
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   detekt:
     name: Detekt
     runs-on: ubuntu-latest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -195,6 +195,15 @@ subprojects {
     tasks.withType<Sign> {
         dependsOn(tasks["build"])
     }
+
+    tasks {
+        // All checks were already made by workflow "On pull request" => no checks here
+        if (gradle.startParameter.taskNames.contains("final")) {
+            named("build").get().apply {
+                dependsOn.removeIf { it == "check" }
+            }
+        }
+    }
 }
 
 nexusPublishing {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ kotlinx-serialization = "1.8.0"
 kover = "0.9.1"
 mockk = "1.13.17"
 nebula = "20.2.0"
+nexus = "2.0.0"
 opentelemetry = "1.48.0"
 opentelemetry-instrumentation-api = "2.14.0"
 opentelemetry-semconv = "1.30.0"
@@ -21,6 +22,7 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 nebula-release = { id = "com.netflix.nebula.release", version.ref = "nebula" }
+nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexus" }
 
 [libraries]
 


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows and updates to the `gradle/libs.versions.toml` file. The most important changes include modifying the publish workflow to use Sonatype, commenting out the publishing step in the verify workflow, and adding the Nexus publish plugin.

Changes to GitHub Actions workflows:

* [`.github/workflows/publish.yaml`](diffhunk://#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388caL55-R62): Modified the publish workflow to include steps for publishing to Sonatype and added environment variables for Sonatype and GPG credentials.
* [`.github/workflows/verify.yaml`](diffhunk://#diff-1440bd8668b126838d91c4736aa5d2dfe6429e97a2e0a45b1a0ac5562ab990ffL55-R59): Commented out the publishing step in the verify workflow to focus on verification tasks.

Updates to `gradle/libs.versions.toml`:

* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR11): Added the Nexus publish plugin version `2.0.0` to the dependencies.
* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR25): Added the Nexus publish plugin configuration.