### PR TITLE
Publish Route Matcher logic for use outside the library

### DIFF
--- a/core/src/main/kotlin/kotlet/AllRoutesMatcher.kt
+++ b/core/src/main/kotlin/kotlet/AllRoutesMatcher.kt
@@ -13,7 +13,10 @@ import java.util.logging.Logger
 
 private val log = Logger.getLogger(AllRoutesMatcher::class.java.simpleName)
 
-internal class AllRoutesMatcher(routes: List<Route>) {
+/**
+ * Routes matcher for all given routes.
+ */
+internal class AllRoutesMatcher(routes: List<Route>): RoutesMatcher {
 
     /**
      * All routes but root router '/' (defined below)
@@ -49,7 +52,10 @@ internal class AllRoutesMatcher(routes: List<Route>) {
             .sortedWith(oneRouteMatcherComparator)
     }
 
-    fun findRoute(request: HttpServletRequest): Pair<Route, Map<String, String>>? {
+    /**
+     * Finds a route for the given request.
+     */
+    override fun findRoute(request: HttpServletRequest): Pair<Route, Map<String, String>>? {
         val matchedRoute = matchers.firstNotNullOfOrNull { routeMatcher ->
             when (val matchResult = routeMatcher.match(request)) {
                 RouteMatchResult.Failure -> null

--- a/core/src/main/kotlin/kotlet/Kotlet.kt
+++ b/core/src/main/kotlin/kotlet/Kotlet.kt
@@ -18,10 +18,10 @@ object Kotlet {
         errorsHandler: ErrorsHandler? = null,
     ): HttpServlet {
         val allRoutes = routings.map(Routing::getAllRoutes).flatten()
-        val allRoutesMatcher = AllRoutesMatcher(allRoutes)
+        val routesMatcher = RoutesMatcher.build(allRoutes)
 
         return RoutingServlet(
-            allRoutesMatcher = allRoutesMatcher,
+            routesMatcher = routesMatcher,
             errorsHandler = errorsHandler ?: ErrorsHandler.DEFAULT
         )
     }

--- a/core/src/main/kotlin/kotlet/OneRouteMatcher.kt
+++ b/core/src/main/kotlin/kotlet/OneRouteMatcher.kt
@@ -4,6 +4,9 @@ import jakarta.servlet.http.HttpServletRequest
 import kotlet.RouteHelpers.RouteMatchResult
 import kotlet.selector.Selector
 
+/**
+ * Route matcher for a single route.
+ */
 internal data class OneRouteMatcher(val route: Route, val selectors: List<Selector>) {
 
     fun match(request: HttpServletRequest): RouteMatchResult {

--- a/core/src/main/kotlin/kotlet/Route.kt
+++ b/core/src/main/kotlin/kotlet/Route.kt
@@ -6,7 +6,7 @@ import kotlet.attributes.RouteAttributes
  * Route configuration.
  * Contains a route path and a list of handlers for different HTTP methods.
  */
-internal data class Route(
+data class Route(
     /**
      * Route path.
      */

--- a/core/src/main/kotlin/kotlet/RoutesMatcher.kt
+++ b/core/src/main/kotlin/kotlet/RoutesMatcher.kt
@@ -1,0 +1,23 @@
+package kotlet
+
+import jakarta.servlet.http.HttpServletRequest
+
+/**
+ * Routes matcher.
+ * This interface is used to find a route for a given request.
+ */
+interface RoutesMatcher {
+    /**
+     * Finds a route for the given request.
+     * This method iterates through all routes and tries to match the request with each route.
+     *
+     * @returns a pair of the matched route and a map of parameters if a match is found, or null if no match is found.
+     */
+    fun findRoute(request: HttpServletRequest): Pair<Route, Map<String, String>>?
+
+    companion object {
+        fun build(routes: List<Route>): RoutesMatcher {
+            return AllRoutesMatcher(routes)
+        }
+    }
+}

--- a/core/src/main/kotlin/kotlet/RoutingServlet.kt
+++ b/core/src/main/kotlin/kotlet/RoutingServlet.kt
@@ -7,17 +7,17 @@ import kotlet.attributes.emptyRouteAttributes
 
 /**
  * Servlet that handles all requests based on the provided routings.
- * It uses [AllRoutesMatcher] to find the route and [ErrorsHandler] to handle errors.
- * @property allRoutesMatcher Matcher that finds the route for the request.
+ * It uses [RoutesMatcher] to find the route and [ErrorsHandler] to handle errors.
+ * @property routesMatcher Matcher that finds the route for the request.
  * @property errorsHandler Handler for errors that occur during request processing.
  */
 internal class RoutingServlet(
-    private val allRoutesMatcher: AllRoutesMatcher,
+    private val routesMatcher: RoutesMatcher,
     private val errorsHandler: ErrorsHandler
 ) : HttpServlet() {
     override fun service(request: HttpServletRequest, response: HttpServletResponse) {
         try {
-            val (route, parameters) = allRoutesMatcher.findRoute(request)
+            val (route, parameters) = routesMatcher.findRoute(request)
                 ?: return errorsHandler.routeNotFound(request, response)
 
             val httpMethod = HttpMethod.parse(request.method)


### PR DESCRIPTION
This pull request introduces several changes to improve the codebase by adding documentation, refactoring class names, and enhancing the route matching functionality. The most important changes include the addition of the `RoutesMatcher` interface, refactoring `AllRoutesMatcher` to implement this interface, and updating the `RoutingServlet` to use the new interface.

Enhancements to route matching:

* [`core/src/main/kotlin/kotlet/RoutesMatcher.kt`](diffhunk://#diff-625e5f883f4dbae045f735b0332b427b4cc41d61f4f13454925901694c3e9421R1-R23): Added a new `RoutesMatcher` interface to define the contract for finding routes. This interface includes a `findRoute` method and a companion object with a `build` method to create instances of `RoutesMatcher`.

Refactoring and documentation improvements:

* [`core/src/main/kotlin/kotlet/AllRoutesMatcher.kt`](diffhunk://#diff-ca345a82948a7f58104a057d61d33b6ff60076fd62759cb4bc6afd340e3d128bL16-R19): Refactored `AllRoutesMatcher` to implement the `RoutesMatcher` interface and added documentation comments to the class and its `findRoute` method. [[1]](diffhunk://#diff-ca345a82948a7f58104a057d61d33b6ff60076fd62759cb4bc6afd340e3d128bL16-R19) [[2]](diffhunk://#diff-ca345a82948a7f58104a057d61d33b6ff60076fd62759cb4bc6afd340e3d128bL52-R58)
* [`core/src/main/kotlin/kotlet/Kotlet.kt`](diffhunk://#diff-94b8890169839656e553d6c79a831dac2ca8e0e7b873b3af881af3bd317e4dbbL21-R24): Updated the creation of `AllRoutesMatcher` to use the `RoutesMatcher.build` method.
* [`core/src/main/kotlin/kotlet/OneRouteMatcher.kt`](diffhunk://#diff-e57a0fdabdbe69d65d8310a4bc7fe57b0ffbab6295a1873880efd5e0ef0871c2R7-R9): Added documentation comments to the `OneRouteMatcher` class.
* [`core/src/main/kotlin/kotlet/RoutingServlet.kt`](diffhunk://#diff-1b2ca8ef518892854f67f9f0daf96f69635cc9fd63385c3425a15828a62387c3L10-R20): Updated the `RoutingServlet` to use the `RoutesMatcher` interface instead of `AllRoutesMatcher`.