### PR TITLE
Add codecov to main

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,48 @@
+name: coverage
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - README.md
+      - '**/README.md'
+      - 'docs/**'
+
+env:
+  JDK_VERSION: 21
+  GRADLE_OPTS: -Dorg.gradle.daemon=false
+
+concurrency:
+  group: ${{ github.workflow }}-push-to-main
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Coverage
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      pull-requests: write
+      packages: write
+      # required for all workflows
+      security-events: write
+      checks: write
+      # only required for workflows in private repositories
+      actions: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Set up JDK ${{ env.JDK_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '${{ env.JDK_VERSION }}'
+          cache: 'gradle'
+      - name: Build and Run Tests
+        run: ./gradlew test koverXmlReport --parallel
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          os: linux-arm64

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -20,9 +20,13 @@ jobs:
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
-      checks: write
       pull-requests: write
       packages: write
+      # required for all workflows
+      security-events: write
+      checks: write
+      # only required for workflows in private repositories
+      actions: read
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -32,6 +36,13 @@ jobs:
           distribution: 'corretto'
           java-version: '${{ env.JDK_VERSION }}'
           cache: 'gradle'
+      - name: Run Detekt
+        run: ./gradlew detekt
+      - name: Publish Detekt Report
+        uses: jwgmeligmeyling/checkstyle-github-action@master
+        if: success() || failure() # always run even if the previous step fails
+        with:
+          path: 'build/reports/detekt/merge.xml'
       - name: Build and Run Tests
         run: ./gradlew test koverXmlReport --parallel
       - name: Publish Test Report
@@ -43,11 +54,13 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          os: linux-arm64
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          os: linux-arm64
       - name: Publish Kover Report
         uses: madrapps/jacoco-report@v1.7.1
         if: success() || failure() # always run even if the previous step fails
@@ -57,38 +70,3 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 50
           min-coverage-changed-files: 60
-      - name: Coverage verify
-        run: ./gradlew koverVerify --parallel
-      # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
-      # the publishing section of your build.gradle
-#      - name: Publish client to GitHub Packages
-#        run: ./gradlew devSnapshot printDevSnapshotReleaseNote
-#        env:
-#          GITHUB_ACTOR: ${{ github.actor }}
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  detekt:
-    name: Detekt
-    runs-on: ubuntu-latest
-    permissions:
-      # required for all workflows
-      security-events: write
-      checks: write
-      # only required for workflows in private repositories
-      actions: read
-      contents: read
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
-      - name: Set up JDK ${{ env.JDK_VERSION }}
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'adopt'
-          java-version: '${{ env.JDK_VERSION }}'
-          cache: 'gradle'
-      - name: Run Detekt
-        run: ./gradlew detekt
-      - name: Publish Detekt Report
-        uses: jwgmeligmeyling/checkstyle-github-action@master
-        if: success() || failure() # always run even if the previous step fails
-        with:
-          path: 'build/reports/detekt/merge.xml'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,11 +23,12 @@ allprojects {
         mavenCentral()
     }
 
+    apply(plugin = "org.jetbrains.kotlinx.kover")
+
     // Unit tests settings
     tasks.withType<Test> {
-        // enable parallel tests execution
-        systemProperties["junit.jupiter.execution.parallel.enabled"] = true
-        systemProperties["junit.jupiter.execution.parallel.mode.default"] = "concurrent"
+        reports.html.required = false
+        reports.junitXml.required = true
 
         // JUnit settings
         useJUnitPlatform {
@@ -76,35 +77,19 @@ subprojects {
     }
 }
 
-// Coverage configuration
-val coverageExclusions = setOf(
-    "benchmarks",
-    "jetty",
-    "mocks",
-    "samples",
-)
+// Kover configuration
 
-subprojects {
-    if (this.name in coverageExclusions) {
-        return@subprojects
-    }
-
-    apply(plugin = "org.jetbrains.kotlinx.kover")
-
+dependencies {
     // register kover for generating merged report from all subprojects
-    rootProject.dependencies {
-        kover(project)
-    }
-
-    kover {
-        reports {
-            verify {
-                rule("Minimal line coverage rate in percents") {
-                    minBound(40)
-                }
-            }
-        }
-    }
+    kover(project(":core"))
+    kover(project(":cors"))
+    kover(project(":json"))
+    kover(project(":jwt"))
+    kover(project(":metrics"))
+    kover(project(":openapi"))
+    kover(project(":swagger-ui"))
+    kover(project(":tracing"))
+    kover(project(":typesafe"))
 }
 
 // Publishing configuration


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for code coverage and makes several updates to the existing verification workflow. The changes aim to streamline the CI process by combining steps and improving coverage reporting.

### New Workflow Addition:
* [`.github/workflows/coverage.yaml`](diffhunk://#diff-3d92b123fe211c36c9df8e06231e1f9f6078331c717fedf2f8396bf31240df1fR1-R48): Added a new workflow to handle code coverage reporting, including setup for JDK 21, running tests, and uploading coverage reports to Codecov.

### Updates to Verification Workflow:
* `.github/workflows/verify.yaml`: 
  * Added permissions for `security-events` and `actions` to the `test` job.
  * Included steps to run and publish Detekt reports within the `test` job, removing the separate `detekt` job.
  * Updated Codecov upload steps to specify the operating system as `linux-arm64`.
  * Removed redundant coverage verification and publishing steps, consolidating them into the `test` job.