### PR TITLE
Clean gradle kts from duplicated configuration

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -61,12 +61,3 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           os: linux-arm64
-      - name: Publish Kover Report
-        uses: madrapps/jacoco-report@v1.7.1
-        if: success() || failure() # always run even if the previous step fails
-        with:
-          paths: |
-            ${{ github.workspace }}/build/reports/kover/report.xml
-          token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 50
-          min-coverage-changed-files: 60

--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -29,10 +29,6 @@ jmh {
     warmupIterations = 3
 }
 
-tasks.test {
-    useJUnitPlatform()
-}
-
 kotlin {
     jvmToolchain(21)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,8 +23,6 @@ allprojects {
         mavenCentral()
     }
 
-    apply(plugin = "org.jetbrains.kotlinx.kover")
-
     // Unit tests settings
     tasks.withType<Test> {
         reports.html.required = false
@@ -77,22 +75,7 @@ subprojects {
     }
 }
 
-// Kover configuration
-
-dependencies {
-    // register kover for generating merged report from all subprojects
-    kover(project(":core"))
-    kover(project(":cors"))
-    kover(project(":json"))
-    kover(project(":jwt"))
-    kover(project(":metrics"))
-    kover(project(":openapi"))
-    kover(project(":swagger-ui"))
-    kover(project(":tracing"))
-    kover(project(":typesafe"))
-}
-
-// Publishing configuration
+// The main packages
 val publishPackages = setOf(
     "core",
     "cors",
@@ -106,6 +89,23 @@ val publishPackages = setOf(
     "typesafe",
 )
 
+// Kover configuration
+dependencies {
+    // register kover for generating merged report from main subprojects
+    publishPackages.forEach {
+        kover(project(":$it"))
+    }
+}
+
+subprojects {
+    if (this.name !in publishPackages) {
+        return@subprojects
+    }
+
+    apply(plugin = "org.jetbrains.kotlinx.kover")
+}
+
+// Publishing configuration
 subprojects {
     if (this.name !in publishPackages) {
         return@subprojects

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,10 +7,10 @@ coverage:
         threshold: 0%
         base: auto
 
-comment:                  #this is a top-level key
+comment: # this is a top-level key
   layout: " diff, flags, files"
   behavior: default
-  require_changes: false  # if true: only post the comment if coverage changes
-  require_base: false        # [true :: must have a base report to post]
-  require_head: true       # [true :: must have a head report to post]
+  require_changes: false       # if true: only post the comment if coverage changes
+  require_base: false          # [true :: must have a base report to post]
+  require_head: true           # [true :: must have a head report to post]
   hide_project_coverage: false # [true :: only show coverage on the git diff aka patch coverage]]

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -9,11 +9,3 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.jakarta.api)
 }
-
-tasks.test {
-    useJUnitPlatform()
-}
-
-kotlin {
-    jvmToolchain(21)
-}

--- a/cors/build.gradle.kts
+++ b/cors/build.gradle.kts
@@ -10,10 +10,3 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.jakarta.api)
 }
-
-tasks.test {
-    useJUnitPlatform()
-}
-kotlin {
-    jvmToolchain(21)
-}

--- a/json/build.gradle.kts
+++ b/json/build.gradle.kts
@@ -13,10 +13,3 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.jakarta.api)
 }
-
-tasks.test {
-    useJUnitPlatform()
-}
-kotlin {
-    jvmToolchain(21)
-}

--- a/jwt/build.gradle.kts
+++ b/jwt/build.gradle.kts
@@ -12,10 +12,3 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.jakarta.api)
 }
-
-tasks.test {
-    useJUnitPlatform()
-}
-kotlin {
-    jvmToolchain(21)
-}

--- a/metrics/build.gradle.kts
+++ b/metrics/build.gradle.kts
@@ -15,11 +15,3 @@ dependencies {
     testImplementation(libs.prometheus.metrics.core)
     testImplementation(libs.prometheus.metrics.exporter.servlet.jakarta)
 }
-
-tasks.test {
-    useJUnitPlatform()
-}
-
-kotlin {
-    jvmToolchain(21)
-}

--- a/mocks/build.gradle.kts
+++ b/mocks/build.gradle.kts
@@ -7,7 +7,3 @@ dependencies {
     compileOnly(libs.jakarta.api)
     implementation(libs.mockk)
 }
-
-kotlin {
-    jvmToolchain(21)
-}

--- a/openapi/build.gradle.kts
+++ b/openapi/build.gradle.kts
@@ -13,11 +13,3 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.jakarta.api)
 }
-
-tasks.test {
-    useJUnitPlatform()
-}
-
-kotlin {
-    jvmToolchain(21)
-}

--- a/swagger-ui/build.gradle.kts
+++ b/swagger-ui/build.gradle.kts
@@ -10,11 +10,3 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.jakarta.api)
 }
-
-tasks.test {
-    useJUnitPlatform()
-}
-
-kotlin {
-    jvmToolchain(21)
-}

--- a/tracing/build.gradle.kts
+++ b/tracing/build.gradle.kts
@@ -14,11 +14,3 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.jakarta.api)
 }
-
-tasks.test {
-    useJUnitPlatform()
-}
-
-kotlin {
-    jvmToolchain(21)
-}

--- a/typesafe/build.gradle.kts
+++ b/typesafe/build.gradle.kts
@@ -10,11 +10,3 @@ dependencies {
     testImplementation(libs.kotlin.test)
     testImplementation(libs.mockk)
 }
-
-tasks.test {
-    useJUnitPlatform()
-}
-
-kotlin {
-    jvmToolchain(21)
-}


### PR DESCRIPTION
This pull request involves removing redundant configurations from various `build.gradle.kts` files across multiple modules. The main changes include the removal of `tasks.test` configurations and `kotlin { jvmToolchain(21) }` settings.

Redundant configuration removal:

* Removed `tasks.test { useJUnitPlatform() }` from `benchmarks/build.gradle.kts`.
* Removed `tasks.test { useJUnitPlatform() }` and `kotlin { jvmToolchain(21) }` from `core/build.gradle.kts`.
* Removed `tasks.test { useJUnitPlatform() }` and `kotlin { jvmToolchain(21) }` from `cors/build.gradle.kts`.
* Removed `tasks.test { useJUnitPlatform() }` and `kotlin { jvmToolchain(21) }` from `json/build.gradle.kts`.
* Removed `tasks.test { useJUnitPlatform() }` and `kotlin { jvmToolchain(21) }` from `jwt/build.gradle.kts`.
* Removed `tasks.test { useJUnitPlatform() }` and `kotlin { jvmToolchain(21) }` from `metrics/build.gradle.kts`.
* Removed `kotlin { jvmToolchain(21) }` from `mocks/build.gradle.kts`.
* Removed `tasks.test { useJUnitPlatform() }` and `kotlin { jvmToolchain(21) }` from `openapi/build.gradle.kts`.
* Removed `tasks.test { useJUnitPlatform() }` and `kotlin { jvmToolchain(21) }` from `swagger-ui/build.gradle.kts`.
* Removed `tasks.test { useJUnitPlatform() }` and `kotlin { jvmToolchain(21) }` from `tracing/build.gradle.kts`.
* Removed `tasks.test { useJUnitPlatform() }` and `kotlin { jvmToolchain(21) }` from `typesafe/build.gradle.kts`.