### PR TITLE
Simplify release tasks

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -46,3 +46,9 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           os: linux-arm64
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          os: linux-arm64

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -54,7 +54,7 @@ jobs:
       # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
       # the publishing section of your build.gradle
       - name: Publish release package to central.sonatype.com
-        run: ./gradlew final closeAndReleaseSonatypeStagingRepository printFinalReleaseNote
+        run: ./gradlew final closeAndReleaseSonatypeStagingRepository
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -53,8 +53,8 @@ jobs:
 
       # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
       # the publishing section of your build.gradle
-      - name: Publish client to GitHub Packages
-        run: ./gradlew final publishToSonatype closeAndReleaseSonatypeStagingRepository printFinalReleaseNote
+      - name: Publish release package to central.sonatype.com
+        run: ./gradlew final closeAndReleaseSonatypeStagingRepository printFinalReleaseNote
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -81,6 +81,11 @@ jobs:
           echo "PR_NOTE<<EOF" >> $GITHUB_OUTPUT
           cat build/pr-note.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+      - name: Remove old PR
+        if: github.event_name == 'pull_request'
+        run: gh pr view ${{ github.event.pull_request.number }} --json comments -q '.comments[] | select(.body | contains("<!-- PR_NOTE_MARKER -->")) | .id' | xargs -r -I {} gh api --method DELETE /repos/${{ github.repository }}/issues/comments/{}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Comment on PR
         if: github.event_name == 'pull_request'
         run: gh pr comment ${{ github.event.pull_request.number }} --body "${{ steps.read_pr_note.outputs.PR_NOTE }}"

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -30,6 +30,9 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
+        with:
+          fetch-tags: 'true'
+          fetch-depth: '0'
       - name: Set up JDK ${{ env.JDK_VERSION }}
         uses: actions/setup-java@v4
         with:
@@ -61,3 +64,14 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           os: linux-arm64
+      # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
+      # the publishing section of your build.gradle
+      - name: Publish snapshot package to central.sonatype.com
+        run: ./gradlew devSnapshot printDevSnapshotReleaseNote
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -75,3 +75,14 @@ jobs:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
+      - name: Read pr note into variable
+        id: read_pr_note
+        run: |
+          echo "PR_NOTE<<EOF" >> $GITHUB_OUTPUT
+          cat build/pr-note.txt >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+      - name: Comment on PR
+        if: github.event_name == 'pull_request'
+        run: gh pr comment ${{ github.event.pull_request.number }} --body "${{ steps.read_pr_note.outputs.PR_NOTE }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -83,7 +83,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
       - name: Remove old PR
         if: github.event_name == 'pull_request'
-        run: gh pr view ${{ github.event.pull_request.number }} --json comments -q '.comments[] | select(.body | contains("<!-- PR_NOTE_MARKER -->")) | .id' | xargs -r -I {} gh api --method DELETE /repos/${{ github.repository }}/issues/comments/{}
+        run: gh pr view ${{ github.event.pull_request.number }} --json comments -q '.comments[] | select(.body | contains("<!-- PR_NOTE_MARKER -->")) | .id' | xargs -r -I {} gh api --method DELETE /repos/${{ github.repository }}/issues/comments/{} || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Comment on PR

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -83,7 +83,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
       - name: Remove old PR
         if: github.event_name == 'pull_request'
-        run: gh pr view ${{ github.event.pull_request.number }} --json comments -q '.comments[] | select(.body | contains("<!-- PR_NOTE_MARKER -->")) | .id' | xargs -r -I {} gh api --method DELETE /repos/${{ github.repository }}/issues/comments/{} || true
+        run: gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --jq '.[] | select(.body | contains("<!-- PR_NOTE_MARKER -->")) | .id' | xargs -r -I {} gh api --method DELETE /repos/${{ github.repository }}/issues/comments/{} || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Comment on PR

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -67,7 +67,7 @@ jobs:
       # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
       # the publishing section of your build.gradle
       - name: Publish snapshot package to central.sonatype.com
-        run: ./gradlew devSnapshot printDevSnapshotReleaseNote
+        run: ./gradlew devSnapshot closeAndReleaseSonatypeStagingRepository printDevSnapshotReleaseNote
         env:
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/benchmarks/src/jmh/kotlin/kotlet/RoutingBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/kotlet/RoutingBenchmark.kt
@@ -1,0 +1,33 @@
+package kotlet
+
+import io.mockk.every
+import io.mockk.mockk
+import jakarta.servlet.http.HttpServletRequest
+import kotlet.Kotlet.routing
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+
+@State(Scope.Benchmark)
+open class RoutingBenchmark {
+    private val routing = routing {
+        repeat(1000) {
+            get("/test/$it") {
+                // do nothing
+            }
+        }
+    }
+
+    private val matcher = RoutesMatcher.create(listOf(routing))
+
+    private val request = mockk<HttpServletRequest>(relaxed = true) {
+        every { pathInfo } returns "/test/XXXXXX"
+    }
+
+    @Benchmark
+    fun testManyRoutes(): Pair<Route, Map<String, String>>? {
+        val found = matcher.findRoute(request)
+        return found
+    }
+
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -260,7 +260,7 @@ tasks.register("printDevSnapshotReleaseNote") {
 
         val note = buildString {
             appendLine("<!-- PR_NOTE_MARKER -->")
-            appendLine("\uD83D\uDCE6 New artifacts were published:")
+            appendLine("New artifacts were published:")
             appendLine("```")
             appendLine("groupId: $groupId")
             appendLine("version: $sanitizedVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -184,10 +184,19 @@ subprojects {
     tasks {
         // All checks were already made by workflow "On pull request" => no checks here
         if (gradle.startParameter.taskNames.contains("final")) {
-            named("build").get().apply {
+            named("build") {
                 dependsOn.removeIf { it == "check" }
             }
         }
+
+        rootProject.tasks.named("final") {
+            dependsOn(named("publishToSonatype"))
+        }
+
+        rootProject.tasks.named("devSnapshot") {
+            dependsOn(named("publishToSonatype"))
+        }
+
     }
 }
 
@@ -245,12 +254,16 @@ tasks.register("printFinalReleaseNote") {
     doLast {
         printReleaseNote()
     }
+
+    dependsOn(tasks["final"])
 }
 
 tasks.register("printDevSnapshotReleaseNote") {
     doLast {
         printReleaseNote()
     }
+
+    dependsOn(tasks["devSnapshot"])
 }
 
 fun printReleaseNote() {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -270,7 +270,7 @@ tasks.register("printDevSnapshotReleaseNote") {
             appendLine("<pre>")
             appendLine("repositories {")
             appendLine("\tmaven {")
-            appendLine("\t\turl = uri(\"https://central.sonatype.com/repository/maven-snapshots/\")")
+            appendLine("\t\turl = uri(&quot;https://central.sonatype.com/repository/maven-snapshots/&quot;)")
             appendLine("\t}")
             appendLine("}")
             appendLine("</pre>")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -260,21 +260,24 @@ tasks.register("printDevSnapshotReleaseNote") {
 
         val note = buildString {
             appendLine("New artifacts were published:")
-            appendLine("\tgroupId: $groupId")
-            appendLine("\tversion: $sanitizedVersion")
-            appendLine("\tartifacts:")
+            appendLine("```")
+            appendLine("groupId: $groupId")
+            appendLine("version: $sanitizedVersion")
+            appendLine("artifacts:")
             publishPackages.sorted().forEach {
-                appendLine("\t\t- kotlet-$it")
+                appendLine("\t- kotlet-$it")
             }
-            appendLine()
+            appendLine("```")
+            appendLine("")
 
             appendLine("Look snapshot versions in https://central.sonatype.com/repository/maven-snapshots/ repository")
-            appendLine()
+            appendLine("```")
             appendLine("repositories {")
             appendLine("\tmaven {")
             appendLine("\t\turl = uri(\"https://central.sonatype.com/repository/maven-snapshots/\")")
             appendLine("\t}")
             appendLine("}")
+            appendLine("```")
         }
 
         outputFile.get().asFile.writeText(note)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -259,7 +259,8 @@ tasks.register("printDevSnapshotReleaseNote") {
         val sanitizedVersion = project.sanitizeVersion()
 
         val note = buildString {
-            appendLine("New artifacts were published:")
+            appendLine("<!-- PR_NOTE_MARKER -->")
+            appendLine("\uD83D\uDCE6 New artifacts were published:")
             appendLine("```")
             appendLine("groupId: $groupId")
             appendLine("version: $sanitizedVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -252,7 +252,7 @@ object ProjectEnvs {
 
 tasks.register("printFinalReleaseNote") {
     doLast {
-        printReleaseNote()
+        printReleaseNote(snapshot = false)
     }
 
     dependsOn(tasks["final"])
@@ -260,13 +260,13 @@ tasks.register("printFinalReleaseNote") {
 
 tasks.register("printDevSnapshotReleaseNote") {
     doLast {
-        printReleaseNote()
+        printReleaseNote(snapshot = true)
     }
 
     dependsOn(tasks["devSnapshot"])
 }
 
-fun printReleaseNote() {
+fun printReleaseNote(snapshot: Boolean) {
     val groupId = project.group
     val sanitizedVersion = project.sanitizeVersion()
 
@@ -281,6 +281,18 @@ fun printReleaseNote() {
         println("\t\t- kotlet-$it")
     }
     println()
+
+    if (snapshot) {
+        println("Look snapshot versions in https://central.sonatype.com/repository/maven-snapshots/ repository")
+        println()
+        println("repositories {")
+        println("\tmaven {")
+        println("\t\turl = uri(\"https://central.sonatype.com/repository/maven-snapshots/\")")
+        println("\t}")
+        println("}")
+        println()
+    }
+
     println("========================================================")
     println()
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -260,15 +260,13 @@ tasks.register("printDevSnapshotReleaseNote") {
 
         val note = buildString {
             appendLine("<!-- PR_NOTE_MARKER -->")
-            appendLine("New artifacts were published:")
-            appendLine("```")
+            appendLine("\uD83D\uDCE6 New artifacts were published:")
             appendLine("groupId: $groupId")
             appendLine("version: $sanitizedVersion")
             appendLine("artifacts:")
             publishPackages.sorted().forEach {
-                appendLine("\t- kotlet-$it")
+                appendLine("  - kotlet-$it")
             }
-            appendLine("```")
             appendLine("")
 
             appendLine("Look snapshot versions in https://central.sonatype.com/repository/maven-snapshots/ repository")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -261,22 +261,19 @@ tasks.register("printDevSnapshotReleaseNote") {
         val note = buildString {
             appendLine("<!-- PR_NOTE_MARKER -->")
             appendLine("\uD83D\uDCE6 New artifacts were published:")
-            appendLine("groupId: $groupId")
-            appendLine("version: $sanitizedVersion")
-            appendLine("artifacts:")
             publishPackages.sorted().forEach {
-                appendLine("  - kotlet-$it")
+                appendLine("  - $groupId:kotlet-$it:$sanitizedVersion")
             }
             appendLine("")
 
-            appendLine("Look snapshot versions in https://central.sonatype.com/repository/maven-snapshots/ repository")
-            appendLine("```")
+            appendLine("Looks snapshot versions in https://central.sonatype.com/repository/maven-snapshots/ repository")
+            appendLine("<pre>")
             appendLine("repositories {")
             appendLine("\tmaven {")
             appendLine("\t\turl = uri(\"https://central.sonatype.com/repository/maven-snapshots/\")")
             appendLine("\t}")
             appendLine("}")
-            appendLine("```")
+            appendLine("</pre>")
         }
 
         outputFile.get().asFile.writeText(note)

--- a/core/src/main/kotlin/kotlet/AllRoutesMatcher.kt
+++ b/core/src/main/kotlin/kotlet/AllRoutesMatcher.kt
@@ -16,7 +16,7 @@ private val log = Logger.getLogger(AllRoutesMatcher::class.java.simpleName)
 /**
  * Routes matcher for all given routes.
  */
-internal class AllRoutesMatcher(routes: List<Route>) {
+internal class AllRoutesMatcher(routes: List<Route>) : RoutesMatcher {
 
     /**
      * All routes but root router '/' (defined below)
@@ -58,7 +58,7 @@ internal class AllRoutesMatcher(routes: List<Route>) {
      *
      * @returns a pair of the matched route and a map of parameters if a match is found, or null if no match is found.
      */
-    fun findRoute(request: HttpServletRequest): Pair<Route, Map<String, String>>? {
+    override fun findRoute(request: HttpServletRequest): Pair<Route, Map<String, String>>? {
         val matchedRoute = matchers.firstNotNullOfOrNull { routeMatcher ->
             when (val matchResult = routeMatcher.match(request)) {
                 RouteMatchResult.Failure -> null

--- a/core/src/main/kotlin/kotlet/Kotlet.kt
+++ b/core/src/main/kotlin/kotlet/Kotlet.kt
@@ -41,11 +41,10 @@ object Kotlet {
          */
         errorsHandler: ErrorsHandler? = null,
     ): HttpServlet {
-        val allRoutes = routings.map(Routing::getAllRoutes).flatten()
-        val allRoutesMatcher = AllRoutesMatcher(allRoutes)
+        val routesMatcher = RoutesMatcher.create(routings)
 
         return RoutingServlet(
-            allRoutesMatcher = allRoutesMatcher,
+            routesMatcher = routesMatcher,
             errorsHandler = errorsHandler ?: ErrorsHandler.DEFAULT
         )
     }

--- a/core/src/main/kotlin/kotlet/Route.kt
+++ b/core/src/main/kotlin/kotlet/Route.kt
@@ -7,7 +7,7 @@ import java.util.EnumSet
  * Route configuration.
  * Contains a route path and a list of handlers for different HTTP methods.
  */
-internal data class Route(
+data class Route(
     /**
      * Route path.
      */

--- a/core/src/main/kotlin/kotlet/RoutesMatcher.kt
+++ b/core/src/main/kotlin/kotlet/RoutesMatcher.kt
@@ -1,0 +1,29 @@
+package kotlet
+
+import jakarta.servlet.http.HttpServletRequest
+
+/**
+ * Interface for matching routes based on the incoming HTTP request.
+ */
+interface RoutesMatcher {
+    /**
+     * Finds a route for the given request.
+     *
+     * @param request the HTTP request to match against the routes.
+     * @returns a pair of the matched route and a map of parameters if a match is found, or null if no match is found.
+     */
+    fun findRoute(request: HttpServletRequest): Pair<Route, Map<String, String>>?
+
+    companion object {
+        /**
+         * Creates a new instance of [RoutesMatcher] with the provided routes.
+         *
+         * @param routings the list of routes to match against.
+         * @returns a new instance of [RoutesMatcher].
+         */
+        fun create(routings: List<Routing>): RoutesMatcher {
+            val allRoutes = routings.map(Routing::getAllRoutes).flatten()
+            return AllRoutesMatcher(allRoutes)
+        }
+    }
+}

--- a/core/src/main/kotlin/kotlet/RoutingServlet.kt
+++ b/core/src/main/kotlin/kotlet/RoutingServlet.kt
@@ -8,16 +8,16 @@ import kotlet.attributes.emptyRouteAttributes
 /**
  * Servlet that handles all requests based on the provided routings.
  * It uses [AllRoutesMatcher] to find the route and [ErrorsHandler] to handle errors.
- * @property allRoutesMatcher Matcher that finds the route for the request.
+ * @property routesMatcher Matcher that finds the route for the request.
  * @property errorsHandler Handler for errors that occur during request processing.
  */
 internal class RoutingServlet(
-    private val allRoutesMatcher: AllRoutesMatcher,
+    private val routesMatcher: RoutesMatcher,
     private val errorsHandler: ErrorsHandler
 ) : HttpServlet() {
     override fun service(request: HttpServletRequest, response: HttpServletResponse) {
         try {
-            val (route, parameters) = allRoutesMatcher.findRoute(request)
+            val (route, parameters) = routesMatcher.findRoute(request)
                 ?: return errorsHandler.routeNotFound(request, response)
 
             val httpMethod = HttpMethod.parse(request.method)
@@ -47,6 +47,6 @@ internal class RoutingServlet(
     }
 
     override fun toString(): String {
-        return "RoutingServlet(routesMatcher=$allRoutesMatcher, errorsHandler=$errorsHandler)"
+        return "RoutingServlet(routesMatcher=$routesMatcher, errorsHandler=$errorsHandler)"
     }
 }

--- a/jwt/src/main/kotlin/kotlet/jwt/HttpCallJwt.kt
+++ b/jwt/src/main/kotlin/kotlet/jwt/HttpCallJwt.kt
@@ -2,6 +2,9 @@ package kotlet.jwt
 
 import kotlet.HttpCall
 
+/**
+ * Returns JWT identity retrieved from [IdentityBuilder]
+ */
 fun <T> HttpCall.identity(): T? {
     @Suppress("UNCHECKED_CAST")
     return this.rawRequest.getAttribute(IDENTITY_PARAMETER_NAME) as? T

--- a/jwt/src/main/kotlin/kotlet/jwt/JWTAuthenticationInterceptor.kt
+++ b/jwt/src/main/kotlin/kotlet/jwt/JWTAuthenticationInterceptor.kt
@@ -30,7 +30,7 @@ internal class JWTAuthenticationInterceptor(
         try {
             val decodedToken = verifier.verify(token)
             call.rawRequest.setAttribute(IDENTITY_PARAMETER_NAME, identityBuilder(decodedToken))
-        } catch (ignored: JWTVerificationException) {
+        } catch (_: JWTVerificationException) {
             // verification failed
         }
 

--- a/jwt/src/test/kotlin/kotlet/jwt/JWTAuthenticationInterceptorUnitTest.kt
+++ b/jwt/src/test/kotlin/kotlet/jwt/JWTAuthenticationInterceptorUnitTest.kt
@@ -65,5 +65,68 @@ class JWTAuthenticationInterceptorUnitTest {
         assertEquals(TestIdentity(scope = "test"), actual)
     }
 
+    @Test
+    fun `interceptor should not set identity without header`() {
+        val verifier = JWT.require(Algorithm.none()).build()
+        val interceptor = JWTAuthenticationInterceptor(verifier) {
+            TestIdentity(scope = it.getClaim("scope").asString())
+        }
+
+
+        val call = Mocks.httpCall(
+            method = HttpMethod.GET,
+            headers = emptyMap()
+        )
+
+        var identity: TestIdentity? = null
+        Interceptors.invokeInterceptor(interceptor, call) {
+            identity = call.identity<TestIdentity>()
+        }
+
+        assertNull(identity)
+    }
+
+    @Test
+    fun `interceptor should not set identity with broken header`() {
+        val verifier = JWT.require(Algorithm.none()).build()
+        val interceptor = JWTAuthenticationInterceptor(verifier) {
+            TestIdentity(scope = it.getClaim("scope").asString())
+        }
+
+
+        val call = Mocks.httpCall(
+            method = HttpMethod.GET,
+            headers = mapOf("Authorization" to "NONE")
+        )
+
+        var identity: TestIdentity? = null
+        Interceptors.invokeInterceptor(interceptor, call) {
+            identity = call.identity<TestIdentity>()
+        }
+
+        assertNull(identity)
+    }
+
+    @Test
+    fun `interceptor should not set identity with broken bearer value`() {
+        val verifier = JWT.require(Algorithm.none()).build()
+        val interceptor = JWTAuthenticationInterceptor(verifier) {
+            TestIdentity(scope = it.getClaim("scope").asString())
+        }
+
+
+        val call = Mocks.httpCall(
+            method = HttpMethod.GET,
+            headers = mapOf("Authorization" to "Bearer NONE")
+        )
+
+        var identity: TestIdentity? = null
+        Interceptors.invokeInterceptor(interceptor, call) {
+            identity = call.identity<TestIdentity>()
+        }
+
+        assertNull(identity)
+    }
+
     private data class TestIdentity(val scope: String)
 }

--- a/jwt/src/test/kotlin/kotlet/jwt/JWTTest.kt
+++ b/jwt/src/test/kotlin/kotlet/jwt/JWTTest.kt
@@ -8,7 +8,7 @@ import kotlin.test.assertEquals
 
 class JWTTest {
     @Test
-    fun `use test`() {
+    fun shouldRegisterJWTInterceptorsForRoutes() {
         val verifier = JWT.require(Algorithm.none()).build()
         val routes = routing {
             useJWTAuthentication(verifier) {

--- a/jwt/src/test/kotlin/kotlet/jwt/JWTTest.kt
+++ b/jwt/src/test/kotlin/kotlet/jwt/JWTTest.kt
@@ -1,0 +1,30 @@
+package kotlet.jwt
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import kotlet.Kotlet.routing
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class JWTTest {
+    @Test
+    fun `use test`() {
+        val verifier = JWT.require(Algorithm.none()).build()
+        val routes = routing {
+            useJWTAuthentication(verifier) {
+                get("/a") {}
+                get("/b") {}
+            }
+        }
+
+        val countOfRoutesWithJWT = routes.registeredRoutes.sumOf { route ->
+            route.interceptors.count {
+                it is JWTAuthenticationInterceptor
+            }
+        }
+
+        assertEquals(2, countOfRoutesWithJWT, "Expected 2 routes with JWT interceptor, but found $countOfRoutesWithJWT")
+    }
+
+
+}

--- a/mocks/src/main/kotlin/kotlet/mocks/http/MockHttpCall.kt
+++ b/mocks/src/main/kotlin/kotlet/mocks/http/MockHttpCall.kt
@@ -93,6 +93,10 @@ private fun createHttpRequestMock(
 ): HttpServletRequest {
     val attributes = mutableMapOf<String, Any>()
 
+
+
+
+
     return mockk {
         every { requestURI } returns path
         every { queryString } returns ""
@@ -136,15 +140,19 @@ private class MockAsyncContext(
     }
 
     override fun dispatch() {
+        // No-op
     }
 
     override fun dispatch(path: String?) {
+        // No-op
     }
 
     override fun dispatch(context: ServletContext?, path: String?) {
+        // No-op
     }
 
     override fun complete() {
+        // No-op
     }
 
     override fun start(run: Runnable) {
@@ -162,16 +170,17 @@ private class MockAsyncContext(
         servletRequest: ServletRequest,
         servletResponse: ServletResponse
     ) {
-        val event = AsyncEvent(this, req, resp)
+        val event = AsyncEvent(this, servletRequest, servletResponse)
         listener.onStartAsync(event)
         listener.onComplete(event)
     }
 
     override fun <T : AsyncListener?> createListener(clazz: Class<T?>?): T? {
-        return null
+        throw UnsupportedOperationException("createListener not supported in mock")
     }
 
     override fun setTimeout(timeout: Long) {
+        // No-op
     }
 
     override fun getTimeout(): Long {

--- a/mocks/src/main/kotlin/kotlet/mocks/http/MockHttpCall.kt
+++ b/mocks/src/main/kotlin/kotlet/mocks/http/MockHttpCall.kt
@@ -84,6 +84,7 @@ class MockHttpCall(
     }
 }
 
+@Suppress("LongParameterList")
 private fun createHttpRequestMock(
     path: String,
     methodName: String,
@@ -178,5 +179,4 @@ private class MockAsyncContext(
     override fun getTimeout(): Long {
         return 0
     }
-
 }

--- a/mocks/src/main/kotlin/kotlet/mocks/http/MockHttpCall.kt
+++ b/mocks/src/main/kotlin/kotlet/mocks/http/MockHttpCall.kt
@@ -2,6 +2,12 @@ package kotlet.mocks.http
 
 import io.mockk.every
 import io.mockk.mockk
+import jakarta.servlet.AsyncContext
+import jakarta.servlet.AsyncEvent
+import jakarta.servlet.AsyncListener
+import jakarta.servlet.ServletContext
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import kotlet.HttpCall
@@ -9,8 +15,7 @@ import kotlet.HttpMethod
 import kotlet.attributes.RouteAttributes
 import kotlet.attributes.emptyRouteAttributes
 import java.io.ByteArrayOutputStream
-import java.util.Collections
-import java.util.Enumeration
+import java.util.*
 
 /**
  * A mock implementation of [HttpCall].
@@ -40,15 +45,8 @@ class MockHttpCall(
     val responseHeaders: MutableMap<String, String> = mutableMapOf()
 
     init {
-        rawRequest = createHttpRequestMock(
-            path = routePath,
-            methodName = httpMethod.name,
-            async = async,
-            headers = headers,
-            requestData = requestData
-        )
-
         val responseHeaders = mutableMapOf<String, String>()
+
         rawResponse = mockk {
             every { outputStream } returns ByteArrayServletOutputStream(responseStream)
             every { setHeader(any(), any()) } answers {
@@ -74,6 +72,15 @@ class MockHttpCall(
                 header.split(",").map(String::trim)
             }
         }
+
+        rawRequest = createHttpRequestMock(
+            path = routePath,
+            methodName = httpMethod.name,
+            async = async,
+            headers = headers,
+            requestData = requestData,
+            response = rawResponse
+        )
     }
 }
 
@@ -83,6 +90,7 @@ private fun createHttpRequestMock(
     async: Boolean,
     headers: Map<String, String>,
     requestData: ByteArray,
+    response: HttpServletResponse
 ): HttpServletRequest {
     val attributes = mutableMapOf<String, Any>()
 
@@ -108,5 +116,67 @@ private fun createHttpRequestMock(
         }
         every { isAsyncStarted } returns async
         every { method } returns methodName
+        every { asyncContext } returns MockAsyncContext(this@mockk, response)
     }
+}
+
+private class MockAsyncContext(
+    private val req: ServletRequest,
+    private val resp: ServletResponse
+): AsyncContext {
+    override fun getRequest(): ServletRequest? {
+        return req
+    }
+
+    override fun getResponse(): ServletResponse? {
+        return resp
+    }
+
+    override fun hasOriginalRequestAndResponse(): Boolean {
+        return true
+    }
+
+    override fun dispatch() {
+    }
+
+    override fun dispatch(path: String?) {
+    }
+
+    override fun dispatch(context: ServletContext?, path: String?) {
+    }
+
+    override fun complete() {
+    }
+
+    override fun start(run: Runnable) {
+        run.run()
+    }
+
+    override fun addListener(listener: AsyncListener) {
+        val event = AsyncEvent(this, req, resp)
+        listener.onStartAsync(event)
+        listener.onComplete(event)
+    }
+
+    override fun addListener(
+        listener: AsyncListener,
+        servletRequest: ServletRequest,
+        servletResponse: ServletResponse
+    ) {
+        val event = AsyncEvent(this, req, resp)
+        listener.onStartAsync(event)
+        listener.onComplete(event)
+    }
+
+    override fun <T : AsyncListener?> createListener(clazz: Class<T?>?): T? {
+        return null
+    }
+
+    override fun setTimeout(timeout: Long) {
+    }
+
+    override fun getTimeout(): Long {
+        return 0
+    }
+
 }

--- a/mocks/src/main/kotlin/kotlet/mocks/http/MockHttpCall.kt
+++ b/mocks/src/main/kotlin/kotlet/mocks/http/MockHttpCall.kt
@@ -45,8 +45,6 @@ class MockHttpCall(
     val responseHeaders: MutableMap<String, String> = mutableMapOf()
 
     init {
-        val responseHeaders = mutableMapOf<String, String>()
-
         rawResponse = mockk {
             every { outputStream } returns ByteArrayServletOutputStream(responseStream)
             every { setHeader(any(), any()) } answers {


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows for publishing and verifying packages. The updates primarily involve modifying the publishing steps to use Sonatype's central repository and adding a new step for publishing snapshot packages.

Changes to publishing steps:

* [`.github/workflows/publish.yaml`](diffhunk://#diff-e81e13daadd1745de51d8b8d85fce1fcd9be355732b64d60a6b56e18c28388caL56-R57): Updated the publishing step to use Sonatype's central repository and simplified the Gradle command.

Changes to verification steps:

* [`.github/workflows/verify.yaml`](diffhunk://#diff-1440bd8668b126838d91c4736aa5d2dfe6429e97a2e0a45b1a0ac5562ab990ffR64-R74): Added a new step to publish snapshot packages to Sonatype's central repository, including necessary environment variables for authentication.