### PR TITLE
Fix JMH test

### DIFF
--- a/benchmarks/src/jmh/kotlin/kotlet/DummyRequest.kt
+++ b/benchmarks/src/jmh/kotlin/kotlet/DummyRequest.kt
@@ -1,0 +1,306 @@
+package kotlet
+
+import jakarta.servlet.AsyncContext
+import jakarta.servlet.DispatcherType
+import jakarta.servlet.RequestDispatcher
+import jakarta.servlet.ServletConnection
+import jakarta.servlet.ServletContext
+import jakarta.servlet.ServletInputStream
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import jakarta.servlet.http.Cookie
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import jakarta.servlet.http.HttpSession
+import jakarta.servlet.http.HttpUpgradeHandler
+import jakarta.servlet.http.Part
+import java.io.BufferedReader
+import java.security.Principal
+import java.util.Enumeration
+import java.util.Locale
+
+class DummyRequest(val path: String) : HttpServletRequest {
+    override fun getAuthType(): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getCookies(): Array<out Cookie?>? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getDateHeader(name: String?): Long {
+        TODO("Not yet implemented")
+    }
+
+    override fun getHeader(name: String?): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getHeaders(name: String?): Enumeration<String?>? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getHeaderNames(): Enumeration<String?>? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getIntHeader(name: String?): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun getMethod(): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getPathInfo(): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getPathTranslated(): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getContextPath(): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getQueryString(): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getRemoteUser(): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun isUserInRole(role: String?): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun getUserPrincipal(): Principal? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getRequestedSessionId(): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getRequestURI(): String? {
+        return path
+    }
+
+    override fun getRequestURL(): StringBuffer? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getServletPath(): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getSession(create: Boolean): HttpSession? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getSession(): HttpSession? {
+        TODO("Not yet implemented")
+    }
+
+    override fun changeSessionId(): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun isRequestedSessionIdValid(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun isRequestedSessionIdFromCookie(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun isRequestedSessionIdFromURL(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun authenticate(response: HttpServletResponse?): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun login(username: String?, password: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun logout() {
+        TODO("Not yet implemented")
+    }
+
+    override fun getParts(): Collection<Part?>? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getPart(name: String?): Part? {
+        TODO("Not yet implemented")
+    }
+
+    override fun <T : HttpUpgradeHandler?> upgrade(handlerClass: Class<T?>?): T? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAttribute(name: String?): Any? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAttributeNames(): Enumeration<String?>? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getCharacterEncoding(): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun setCharacterEncoding(encoding: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getContentLength(): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun getContentLengthLong(): Long {
+        TODO("Not yet implemented")
+    }
+
+    override fun getContentType(): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getInputStream(): ServletInputStream? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getParameter(name: String?): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getParameterNames(): Enumeration<String?>? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getParameterValues(name: String?): Array<out String?>? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getParameterMap(): Map<String?, Array<out String?>?>? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getProtocol(): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getScheme(): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getServerName(): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getServerPort(): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun getReader(): BufferedReader? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getRemoteAddr(): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getRemoteHost(): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun setAttribute(name: String?, o: Any?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun removeAttribute(name: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getLocale(): Locale? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getLocales(): Enumeration<Locale?>? {
+        TODO("Not yet implemented")
+    }
+
+    override fun isSecure(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun getRequestDispatcher(path: String?): RequestDispatcher? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getRemotePort(): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun getLocalName(): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getLocalAddr(): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getLocalPort(): Int {
+        TODO("Not yet implemented")
+    }
+
+    override fun getServletContext(): ServletContext? {
+        TODO("Not yet implemented")
+    }
+
+    override fun startAsync(): AsyncContext? {
+        TODO("Not yet implemented")
+    }
+
+    override fun startAsync(
+        servletRequest: ServletRequest?,
+        servletResponse: ServletResponse?
+    ): AsyncContext? {
+        TODO("Not yet implemented")
+    }
+
+    override fun isAsyncStarted(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun isAsyncSupported(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAsyncContext(): AsyncContext? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getDispatcherType(): DispatcherType? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getRequestId(): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getProtocolRequestId(): String? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getServletConnection(): ServletConnection? {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/benchmarks/src/jmh/kotlin/kotlet/RoutingBenchmark.kt
+++ b/benchmarks/src/jmh/kotlin/kotlet/RoutingBenchmark.kt
@@ -1,8 +1,5 @@
 package kotlet
 
-import io.mockk.every
-import io.mockk.mockk
-import jakarta.servlet.http.HttpServletRequest
 import kotlet.Kotlet.routing
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.Scope
@@ -19,15 +16,11 @@ open class RoutingBenchmark {
     }
 
     private val matcher = RoutesMatcher.create(listOf(routing))
-
-    private val request = mockk<HttpServletRequest>(relaxed = true) {
-        every { pathInfo } returns "/test/XXXXXX"
-    }
+    private val request = DummyRequest("/test/XXXXXX")
 
     @Benchmark
     fun testManyRoutes(): Pair<Route, Map<String, String>>? {
-        val found = matcher.findRoute(request)
-        return found
+        return matcher.findRoute(request)
     }
 
 }

--- a/core/src/main/kotlin/kotlet/RouteHelpers.kt
+++ b/core/src/main/kotlin/kotlet/RouteHelpers.kt
@@ -20,7 +20,25 @@ internal object RouteHelpers {
     private const val TAIL_SEGMENT = "{...}"
 
     fun parsePathToSegments(path: String): List<String> {
-        return path.split('/').filter { it.isNotBlank() }
+        val segments = mutableListOf<String>()
+        var start = 0
+        val length = path.length
+
+        for (i in 0 until length) {
+            if (path[i] == '/') {
+                if (start < i) {
+                    segments.add(path.substring(start, i))
+                }
+                start = i + 1
+            }
+        }
+
+        // add last segment if it is not empty
+        if (start < length) {
+            segments.add(path.substring(start))
+        }
+
+        return segments
     }
 
     fun prepareSelectorsList(route: Route): List<Selector> {


### PR DESCRIPTION
This pull request introduces a new `DummyRequest` class to replace the mock `HttpServletRequest` in the routing benchmarks and optimizes the path parsing logic. The most important changes include the creation of the `DummyRequest` class, updating the routing benchmark to use this new class, and optimizing the `parsePathToSegments` method.

### New `DummyRequest` Class:

* [`benchmarks/src/jmh/kotlin/kotlet/DummyRequest.kt`](diffhunk://#diff-b3d67b98c1bbe11e0c8419fcbe17a9d2eb74fc8bf07e4798f873abb1f094b4d5R1-R306): Added a new `DummyRequest` class implementing the `HttpServletRequest` interface with a constructor that accepts a path string. This class currently has many unimplemented methods.

### Benchmark Update:

* [`benchmarks/src/jmh/kotlin/kotlet/RoutingBenchmark.kt`](diffhunk://#diff-2c36f3363cf9ac16b7f287bc34894f746f12dbde5943f24d9a1b1efa16b5ebdeL22-R23): Updated the `RoutingBenchmark` class to use the new `DummyRequest` class instead of a mocked `HttpServletRequest`.

### Path Parsing Optimization:

* [`core/src/main/kotlin/kotlet/RouteHelpers.kt`](diffhunk://#diff-424bee945d978f58eb590f2ea035fb87840f77ba6e1bc2e03b0298b6d31a92b7L23-R41): Optimized the `parsePathToSegments` method by replacing the `split` and `filter` approach with a more efficient manual parsing loop.