### PR TITLE
Not publish from dependabot

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -67,6 +67,7 @@ jobs:
       # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
       # the publishing section of your build.gradle
       - name: Publish snapshot package to central.sonatype.com
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: ./gradlew devSnapshot closeAndReleaseSonatypeStagingRepository printDevSnapshotReleaseNote
         env:
           GITHUB_ACTOR: ${{ github.actor }}
@@ -76,18 +77,19 @@ jobs:
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
       - name: Read pr note into variable
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         id: read_pr_note
         run: |
           echo "PR_NOTE<<EOF" >> $GITHUB_OUTPUT
           cat build/pr-note.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
       - name: Remove old PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'
         run: gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --jq '.[] | select(.body | contains("<!-- PR_NOTE_MARKER -->")) | .id' | xargs -r -I {} gh api --method DELETE /repos/${{ github.repository }}/issues/comments/{} || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Comment on PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]'
         run: gh pr comment ${{ github.event.pull_request.number }} --body "${{ steps.read_pr_note.outputs.PR_NOTE }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow to exclude actions for pull requests created by Dependabot. The most important changes include adding conditions to various workflow steps to check if the pull request is not created by the Dependabot user.

Changes to GitHub Actions workflow:

* [`.github/workflows/verify.yaml`](diffhunk://#diff-1440bd8668b126838d91c4736aa5d2dfe6429e97a2e0a45b1a0ac5562ab990ffR70): Added conditions to the `Publish snapshot package to central.sonatype.com`, `Read pr note into variable`, `Remove old PR`, and `Comment on PR` steps to ensure they do not run for pull requests created by `dependabot[bot]`. [[1]](diffhunk://#diff-1440bd8668b126838d91c4736aa5d2dfe6429e97a2e0a45b1a0ac5562ab990ffR70) [[2]](diffhunk://#diff-1440bd8668b126838d91c4736aa5d2dfe6429e97a2e0a45b1a0ac5562ab990ffR80-R92)