### PR TITLE
Registered routes interceptors

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.1.20" />
+    <option name="version" value="2.1.21" />
   </component>
 </project>

--- a/core/src/main/kotlin/kotlet/Routing.kt
+++ b/core/src/main/kotlin/kotlet/Routing.kt
@@ -734,7 +734,7 @@ class Routing internal constructor() {
                 RegisteredRoute(
                     path = route.path,
                     method = route.method,
-                    interceptors = route.options.interceptors,
+                    interceptors = globalInterceptors.toOrderedInterceptorList() + route.options.interceptors,
                     attributes = route.options.attributes,
                 )
             }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/json/src/test/kotlin/kotlet/RoutingUnitTest.kt
+++ b/json/src/test/kotlin/kotlet/RoutingUnitTest.kt
@@ -1,7 +1,7 @@
 package kotlet
 
-import org.junit.jupiter.api.Assertions.*
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class RoutingUnitTest {
     @Test

--- a/json/src/test/kotlin/kotlet/RoutingUnitTest.kt
+++ b/json/src/test/kotlin/kotlet/RoutingUnitTest.kt
@@ -1,0 +1,30 @@
+package kotlet
+
+import org.junit.jupiter.api.Assertions.*
+import kotlin.test.Test
+
+class RoutingUnitTest {
+    @Test
+    fun `registered routes contains info about all interceptors`() {
+        val routing = Kotlet.routing {
+            install(GlobalInterceptor)
+            get("/only_global") {}
+            use(LocalInterceptor) {
+                get("/global_and_local") {}
+            }
+        }
+
+        val routes = routing.registeredRoutes
+
+        val globalRoute = routes.first { it.path == "/only_global" }
+        val globalAndLocalRoute = routes.first { it.path == "/global_and_local" }
+
+        assertEquals(globalRoute.interceptors, listOf(GlobalInterceptor))
+        assertEquals(globalAndLocalRoute.interceptors, listOf(GlobalInterceptor, LocalInterceptor))
+    }
+
+}
+
+private data object GlobalInterceptor : Interceptor
+
+private data object LocalInterceptor : Interceptor


### PR DESCRIPTION
This pull request includes updates to dependencies, a functional change in the `Routing` class, and the addition of a new unit test to validate the behavior of route interceptors. Below is a summary of the most important changes:

### Dependency Updates:
* Updated the Kotlin plugin version in `.idea/kotlinc.xml` from `2.1.20` to `2.1.21` to use the latest features and fixes.
* Updated the Gradle wrapper version in `gradle-wrapper.properties` from `8.13` to `8.14.2` to ensure compatibility with newer Gradle features.

### Functional Changes:
* Modified the `Routing` class in `Routing.kt` to prepend `globalInterceptors` to the route-specific interceptors using the `toOrderedInterceptorList` method. This ensures global interceptors are consistently applied to all routes.

### Testing Enhancements:
* Added a new unit test class, `RoutingUnitTest`, in `RoutingUnitTest.kt` to verify that registered routes correctly include all applicable interceptors (global and local). This improves test coverage for the routing functionality.