### PR TITLE
Add max-age support to CORS configuration

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.1.21" />
+    <option name="version" value="2.2.10" />
   </component>
 </project>

--- a/cors/src/main/kotlin/kotlet/cors/CORS.kt
+++ b/cors/src/main/kotlin/kotlet/cors/CORS.kt
@@ -3,6 +3,7 @@ package kotlet.cors
 import kotlet.InstallOrder
 import kotlet.Interceptor
 import kotlet.Routing
+import java.time.Duration
 
 private const val ALLOW_ALL_ORIGINS = "*"
 
@@ -11,6 +12,7 @@ private val DEFAULT_ALLOWED_HEADERS =
 
 private val ALLOW_ALL_METHODS = listOf("*")
 
+private val DEFAULT_MAX_AGE = Duration.ofMinutes(10)
 
 object CORS {
     /**
@@ -21,6 +23,7 @@ object CORS {
             allowOrigin = ALLOW_ALL_ORIGINS,
             allowMethods = ALLOW_ALL_METHODS,
             allowHeaders = DEFAULT_ALLOWED_HEADERS,
+            maxAge = DEFAULT_MAX_AGE
         )
         ConstantCorsRules(headers)
     }
@@ -33,6 +36,7 @@ object CORS {
             allowOrigin = origin,
             allowMethods = ALLOW_ALL_METHODS,
             allowHeaders = DEFAULT_ALLOWED_HEADERS,
+            maxAge = DEFAULT_MAX_AGE
         )
         return ConstantCorsRules(headers)
     }

--- a/cors/src/main/kotlin/kotlet/cors/CorsInterceptor.kt
+++ b/cors/src/main/kotlin/kotlet/cors/CorsInterceptor.kt
@@ -23,6 +23,9 @@ internal data class CorsInterceptor(
                 call.rawResponse.setHeader("Access-Control-Allow-Origin", response.allowOrigin)
                 call.rawResponse.setHeader("Access-Control-Allow-Methods", response.allowMethods)
                 call.rawResponse.setHeader("Access-Control-Allow-Headers", response.allowHeaders)
+                if (response.maxAgeSeconds.isNotEmpty()) {
+                    call.rawResponse.setHeader("Access-Control-Max-Age", response.maxAgeSeconds)
+                }
                 call.status = HttpServletResponse.SC_OK
             }
 

--- a/cors/src/main/kotlin/kotlet/cors/CorsResponse.kt
+++ b/cors/src/main/kotlin/kotlet/cors/CorsResponse.kt
@@ -75,7 +75,7 @@ sealed class CorsResponse {
              */
             maxAge: Duration = Duration.ZERO,
         ): CorsResponse {
-            val maxAgeSeconds = if (!maxAge.isZero && !maxAge.isNegative && maxAge.seconds > 0) {
+            val maxAgeSeconds = if (maxAge.seconds > 0) {
                 maxAge.seconds.toString()
             } else {
                 ""

--- a/cors/src/main/kotlin/kotlet/cors/CorsResponse.kt
+++ b/cors/src/main/kotlin/kotlet/cors/CorsResponse.kt
@@ -48,23 +48,23 @@ sealed class CorsResponse {
          */
         fun headers(
             /**
-             * The Access-Control-Allow-Origin response header indicates whether the response can be shared with requesting
-             * code from the given origin.
+             * The Access-Control-Allow-Origin response header indicates whether the response can be shared with
+             * requesting code from the given origin.
              * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
              */
             allowOrigin: String,
 
             /**
-             * The Access-Control-Allow-Methods response header specifies one or more methods allowed when accessing a
-             * resource in response to a preflight request.
+             * The Access-Control-Allow-Methods response header specifies one or more methods allowed when accessing
+             * a resource in response to a preflight request.
              * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods
              */
             allowMethods: List<String>,
 
             /**
-             * The Access-Control-Allow-Headers response header is used in response to a preflight request which includes
-             * the Access-Control-Request-Headers to indicate which HTTP headers can be used during the actual request.
-             * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
+             * The Access-Control-Allow-Headers response header is used in response to a preflight request which
+             * includes the Access-Control-Request-Headers to indicate which HTTP headers can be used during the
+             * actual request. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
              */
             allowHeaders: List<String>,
 

--- a/cors/src/main/kotlin/kotlet/cors/CorsResponse.kt
+++ b/cors/src/main/kotlin/kotlet/cors/CorsResponse.kt
@@ -1,5 +1,11 @@
 package kotlet.cors
 
+import java.time.Duration
+
+/**
+ * The result of evaluating [CorsRules] for a given request.
+ * Can be either [Headers] or [Error].
+ */
 sealed class CorsResponse {
     internal data class Headers(
         /**
@@ -21,7 +27,14 @@ sealed class CorsResponse {
          * the Access-Control-Request-Headers to indicate which HTTP headers can be used during the actual request.
          * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
          */
-        val allowHeaders: String
+        val allowHeaders: String,
+
+        /**
+         * The HTTP Access-Control-Max-Age response header indicates how long the results of a preflight request
+         * (that is, the information contained in the Access-Control-Allow-Methods and Access-Control-Allow-Headers
+         * headers) can be cached. Not specified if empty.
+         */
+        val maxAgeSeconds: String
     ) : CorsResponse()
 
     internal data class Error(
@@ -34,14 +47,45 @@ sealed class CorsResponse {
          * Creates a [CorsResponse] with the given headers.
          */
         fun headers(
+            /**
+             * The Access-Control-Allow-Origin response header indicates whether the response can be shared with requesting
+             * code from the given origin.
+             * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
+             */
             allowOrigin: String,
+
+            /**
+             * The Access-Control-Allow-Methods response header specifies one or more methods allowed when accessing a
+             * resource in response to a preflight request.
+             * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods
+             */
             allowMethods: List<String>,
+
+            /**
+             * The Access-Control-Allow-Headers response header is used in response to a preflight request which includes
+             * the Access-Control-Request-Headers to indicate which HTTP headers can be used during the actual request.
+             * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers
+             */
             allowHeaders: List<String>,
+
+            /**
+             * The HTTP Access-Control-Max-Age response header indicates how long the results of a preflight request
+             * (that is, the information contained in the Access-Control-Allow-Methods and Access-Control-Allow-Headers
+             * headers) can be cached. Not specified if empty.
+             */
+            maxAge: Duration = Duration.ZERO,
         ): CorsResponse {
+            val maxAgeSeconds = if (!maxAge.isZero && !maxAge.isNegative && maxAge.seconds > 0) {
+                maxAge.seconds.toString()
+            } else {
+                ""
+            }
+
             return Headers(
                 allowOrigin = allowOrigin,
                 allowMethods = allowMethods.distinct().joinToString(separator = ", "),
                 allowHeaders = allowHeaders.distinct().joinToString(separator = ", "),
+                maxAgeSeconds = maxAgeSeconds
             )
         }
 

--- a/cors/src/test/kotlin/kotlet/cors/CORSUnitTest.kt
+++ b/cors/src/test/kotlin/kotlet/cors/CORSUnitTest.kt
@@ -65,7 +65,7 @@ class CORSUnitTest {
             call.status = 200
             response.setHeader("Access-Control-Allow-Origin", "https://example.com")
             response.setHeader("Access-Control-Allow-Methods", "*")
-            response.setHeader("Access-Control-Allow-Methods", "*")
+            response.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization")
             response.setHeader("Access-Control-Max-Age", "20")
         }
     }


### PR DESCRIPTION
This pull request introduces support for the `Access-Control-Max-Age` header in the CORS implementation, allowing preflight request results to be cached for a specified duration. It also updates the Kotlin compiler version and adds comprehensive tests for the new functionality.

**CORS header improvements:**

* Added support for the `Access-Control-Max-Age` header to the `CorsResponse.Headers` class, enabling configuration of how long preflight request results can be cached. The default max age is set to 10 minutes (`Duration.ofMinutes(10)`), and the header is only included if a positive value is specified. [[1]](diffhunk://#diff-92ee707c4e8d9e7f88568e14dc3f7d922847c3532445f3a92f9d7e2e62e95d06L24-R37) [[2]](diffhunk://#diff-92ee707c4e8d9e7f88568e14dc3f7d922847c3532445f3a92f9d7e2e62e95d06R50-R88) [[3]](diffhunk://#diff-473533ba931e5130f8b09091cc1e4b1309cbc00bfac2e7ac979af531af664b5eR15) [[4]](diffhunk://#diff-473533ba931e5130f8b09091cc1e4b1309cbc00bfac2e7ac979af531af664b5eR26) [[5]](diffhunk://#diff-473533ba931e5130f8b09091cc1e4b1309cbc00bfac2e7ac979af531af664b5eR39) [[6]](diffhunk://#diff-59b83187112bc7023b712c027753633874a3ca7d5c7154c6a17684b5791b18b0R26-R28)
* Updated the CORS interceptor to set the `Access-Control-Max-Age` header in HTTP responses when applicable.

**Testing enhancements:**

* Added and updated unit tests to verify correct handling and presence of the `Access-Control-Max-Age` header, including cases where the header should not be set. [[1]](diffhunk://#diff-aa1c446c684fedd784a0fb82b0300d10fa2d534199402ef6c01da8334634f1c7R24) [[2]](diffhunk://#diff-aa1c446c684fedd784a0fb82b0300d10fa2d534199402ef6c01da8334634f1c7R35) [[3]](diffhunk://#diff-aa1c446c684fedd784a0fb82b0300d10fa2d534199402ef6c01da8334634f1c7L42-R46) [[4]](diffhunk://#diff-aa1c446c684fedd784a0fb82b0300d10fa2d534199402ef6c01da8334634f1c7L64-R69) [[5]](diffhunk://#diff-aa1c446c684fedd784a0fb82b0300d10fa2d534199402ef6c01da8334634f1c7R100) [[6]](diffhunk://#diff-aa1c446c684fedd784a0fb82b0300d10fa2d534199402ef6c01da8334634f1c7R132-R172)

**Dependency update:**

* Upgraded the Kotlin compiler version from `2.1.21` to `2.2.10` in `.idea/kotlinc.xml`.