### PR TITLE
Refactor CORS header handling to use setHeader method for consistency

### DIFF
--- a/cors/src/main/kotlin/kotlet/cors/CorsInterceptor.kt
+++ b/cors/src/main/kotlin/kotlet/cors/CorsInterceptor.kt
@@ -20,16 +20,17 @@ internal data class CorsInterceptor(
 
         when (val response = rules.getResponse(call)) {
             is CorsResponse.Headers -> {
+                call.status = HttpServletResponse.SC_OK
+
                 with(call.rawResponse) {
-                    addHeader("Access-Control-Allow-Origin", response.allowOrigin)
-                    addHeader("Access-Control-Allow-Methods", response.allowMethods)
-                    addHeader("Access-Control-Allow-Headers", response.allowHeaders)
+                    setHeader("Access-Control-Allow-Origin", response.allowOrigin)
+                    setHeader("Access-Control-Allow-Methods", response.allowMethods)
+                    setHeader("Access-Control-Allow-Headers", response.allowHeaders)
 
                     if (response.maxAgeSeconds.isNotEmpty()) {
-                        addHeader("Access-Control-Max-Age", response.maxAgeSeconds)
+                        setHeader("Access-Control-Max-Age", response.maxAgeSeconds)
                     }
                 }
-                call.status = HttpServletResponse.SC_OK
             }
 
             is CorsResponse.Error -> {

--- a/cors/src/test/kotlin/kotlet/cors/CORSUnitTest.kt
+++ b/cors/src/test/kotlin/kotlet/cors/CORSUnitTest.kt
@@ -50,7 +50,7 @@ class CORSUnitTest {
         })
 
         val response = mockk<HttpServletResponse> {
-            every { addHeader(any(), any()) } just Runs
+            every { setHeader(any(), any()) } just Runs
         }
         val call = mockk<HttpCall> {
             every { httpMethod } returns HttpMethod.OPTIONS
@@ -64,10 +64,10 @@ class CORSUnitTest {
 
         verify {
             call.status = 200
-            response.addHeader("Access-Control-Allow-Origin", "https://example.com")
-            response.addHeader("Access-Control-Allow-Methods", "*")
-            response.addHeader("Access-Control-Allow-Headers", "Content-Type, Authorization")
-            response.addHeader("Access-Control-Max-Age", "20")
+            response.setHeader("Access-Control-Allow-Origin", "https://example.com")
+            response.setHeader("Access-Control-Allow-Methods", "*")
+            response.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization")
+            response.setHeader("Access-Control-Max-Age", "20")
         }
 
         confirmVerified(response)
@@ -153,7 +153,7 @@ class CORSUnitTest {
         })
 
         val response = mockk<HttpServletResponse> {
-            every { addHeader(any(), any()) } just Runs
+            every { setHeader(any(), any()) } just Runs
         }
         val call = mockk<HttpCall> {
             every { httpMethod } returns HttpMethod.OPTIONS
@@ -170,7 +170,7 @@ class CORSUnitTest {
         }
 
         verify(exactly = 0) {
-            response.addHeader("Access-Control-Max-Age", any())
+            response.setHeader("Access-Control-Max-Age", any())
         }
     }
 }

--- a/cors/src/test/kotlin/kotlet/cors/CorsIntegration.kt
+++ b/cors/src/test/kotlin/kotlet/cors/CorsIntegration.kt
@@ -32,13 +32,13 @@ class CorsIntegration {
 
         verify {
             call.status = 200
-            call.rawResponse.addHeader("Access-Control-Allow-Origin", "*")
-            call.rawResponse.addHeader("Access-Control-Allow-Methods", "*")
-            call.rawResponse.addHeader(
+            call.rawResponse.setHeader("Access-Control-Allow-Origin", "*")
+            call.rawResponse.setHeader("Access-Control-Allow-Methods", "*")
+            call.rawResponse.setHeader(
                 "Access-Control-Allow-Headers",
                 "Accept, Authorization, Accept-Language, Content-Language, Content-Type"
             )
-            call.rawResponse.addHeader("Access-Control-Max-Age", "600")
+            call.rawResponse.setHeader("Access-Control-Max-Age", "600")
         }
 
         confirmVerified(call.rawResponse)


### PR DESCRIPTION
This pull request updates how CORS headers are set in both the implementation and tests to use `setHeader` instead of `addHeader`. This change ensures that headers are overwritten rather than appended, which is the standard behavior for CORS responses. The tests have also been updated to verify this new behavior.

**CORS header handling improvements:**

* In `CorsInterceptor.kt`, changed all CORS header assignments from `addHeader` to `setHeader` to ensure headers are correctly overwritten for each response. Also moved the status assignment to occur before setting headers.

**Test updates for new header handling:**

* Updated all usages of `addHeader` to `setHeader` in `CORSUnitTest.kt` to match the new implementation and adjusted verifications accordingly. [[1]](diffhunk://#diff-aa1c446c684fedd784a0fb82b0300d10fa2d534199402ef6c01da8334634f1c7L53-R53) [[2]](diffhunk://#diff-aa1c446c684fedd784a0fb82b0300d10fa2d534199402ef6c01da8334634f1c7L67-R70) [[3]](diffhunk://#diff-aa1c446c684fedd784a0fb82b0300d10fa2d534199402ef6c01da8334634f1c7L156-R156) [[4]](diffhunk://#diff-aa1c446c684fedd784a0fb82b0300d10fa2d534199402ef6c01da8334634f1c7L173-R173)
* Updated header verification in `CorsIntegration.kt` to use `setHeader` instead of `addHeader`.