### PR TITLE
Refactor CORS interceptor to handle preflight requests and set Allow-…

### DIFF
--- a/cors/src/main/kotlin/kotlet/cors/CorsInterceptor.kt
+++ b/cors/src/main/kotlin/kotlet/cors/CorsInterceptor.kt
@@ -29,8 +29,7 @@ internal data class CorsInterceptor(
                 }
 
                 is CorsResponse.Error -> {
-                    call.status = response.statusCode
-                    call.respondText(response.message)
+                    call.respondError(response.statusCode, response.message)
 
                     // Abort the call chain on CORS error
                     return
@@ -68,8 +67,7 @@ internal data class CorsInterceptor(
             }
 
             is CorsResponse.Error -> {
-                call.status = response.statusCode
-                call.respondText(response.message)
+                call.respondError(response.statusCode, response.message)
             }
         }
     }

--- a/cors/src/main/kotlin/kotlet/cors/CorsInterceptor.kt
+++ b/cors/src/main/kotlin/kotlet/cors/CorsInterceptor.kt
@@ -14,19 +14,53 @@ internal data class CorsInterceptor(
     private val rules: CorsRules
 ) : Interceptor {
     override fun aroundCall(call: HttpCall, next: Handler) {
-        if (call.httpMethod != HttpMethod.OPTIONS) {
-            return next(call)
+        if (call.httpMethod == HttpMethod.OPTIONS) {
+            processPreflightRequest(call)
+
+            // This is a preflight request, so we don't need to continue
+            // Abort the call chain
+            return
         }
 
+        if (isCorsRequest(call)) {
+            when (val response = rules.getResponse(call)) {
+                is CorsResponse.Headers -> {
+                    writeAllowOriginHeader(call, response)
+                }
+
+                is CorsResponse.Error -> {
+                    call.status = response.statusCode
+                    call.respondText(response.message)
+
+                    // Abort the call chain on CORS error
+                    return
+                }
+            }
+        }
+
+        // Not a preflight request, continue the call chain
+        next(call)
+    }
+
+    /**
+     * Determines if the request is a CORS request by checking for the presence of the "Origin" header.
+     */
+    private fun isCorsRequest(call: HttpCall): Boolean {
+        val hasOrigin = !call.rawRequest.getHeader("Origin").isNullOrEmpty()
+        return hasOrigin
+    }
+
+    /**
+     * Processes a CORS preflight request.
+     */
+    private fun processPreflightRequest(call: HttpCall) {
         when (val response = rules.getResponse(call)) {
             is CorsResponse.Headers -> {
                 call.status = HttpServletResponse.SC_OK
-
+                writeAllowOriginHeader(call, response)
                 with(call.rawResponse) {
-                    setHeader("Access-Control-Allow-Origin", response.allowOrigin)
                     setHeader("Access-Control-Allow-Methods", response.allowMethods)
                     setHeader("Access-Control-Allow-Headers", response.allowHeaders)
-
                     if (response.maxAgeSeconds.isNotEmpty()) {
                         setHeader("Access-Control-Max-Age", response.maxAgeSeconds)
                     }
@@ -38,8 +72,15 @@ internal data class CorsInterceptor(
                 call.respondText(response.message)
             }
         }
+    }
 
-        // This is a preflight request, so we don't need to continue
-        // Abort the call chain
+    private fun writeAllowOriginHeader(call: HttpCall, corsResponse: CorsResponse.Headers) {
+        with(call.rawResponse) {
+            val allowOrigin = corsResponse.allowOrigin
+            setHeader("Access-Control-Allow-Origin", allowOrigin)
+            if (allowOrigin != CORS.ALL_ORIGINS) {
+                setHeader("Vary", "Origin")
+            }
+        }
     }
 }

--- a/cors/src/test/kotlin/kotlet/cors/CORSUnitTest.kt
+++ b/cors/src/test/kotlin/kotlet/cors/CORSUnitTest.kt
@@ -90,6 +90,7 @@ class CORSUnitTest {
             every { httpMethod } returns HttpMethod.OPTIONS
             every { rawResponse } returns response
             every { respondText(any()) } just Runs
+            every { respondError(any(), any()) } just Runs
         }
         every { call setProperty ("status") value any<Int>() } just Runs
 
@@ -106,8 +107,7 @@ class CORSUnitTest {
         }
 
         verify {
-            call.status = 403
-            call.respondText("Forbidden")
+            call.respondError(403, "Forbidden")
         }
     }
 

--- a/cors/src/test/kotlin/kotlet/cors/CORSUnitTest.kt
+++ b/cors/src/test/kotlin/kotlet/cors/CORSUnitTest.kt
@@ -9,6 +9,7 @@ import io.mockk.verify
 import jakarta.servlet.http.HttpServletResponse
 import kotlet.HttpCall
 import kotlet.HttpMethod
+import kotlet.mocks.Mocks
 import java.time.Duration
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -68,6 +69,7 @@ class CORSUnitTest {
             response.setHeader("Access-Control-Allow-Methods", "*")
             response.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization")
             response.setHeader("Access-Control-Max-Age", "20")
+            response.setHeader("Vary", "Origin")
         }
 
         confirmVerified(response)
@@ -113,31 +115,35 @@ class CORSUnitTest {
     fun testNotPreflightRequest() {
         val interceptor = CORS.interceptor(CORS.allowAll)
 
-        val response = mockk<HttpServletResponse> {
-            every { setHeader(any(), any()) } just Runs
-        }
-        val call = mockk<HttpCall> {
-            every { httpMethod } returns HttpMethod.GET
-            every { rawResponse } returns response
-        }
-        every { call setProperty ("status") value any<Int>() } just Runs
+        val call = Mocks.httpCall(
+            method = HttpMethod.GET,
+            headers = mapOf(
+                "Origin" to "https://example.com"
+            )
+        )
 
         interceptor.aroundCall(call) {
             // set status to 201 for checking
             call.status = 201
         }
 
+        // only allow origin header should be set
+        verify {
+            call.rawResponse.setHeader("Access-Control-Allow-Origin", "*")
+        }
+
         // headers should not be set
         verify(exactly = 0) {
-            response.setHeader("Access-Control-Allow-Origin", any())
-            response.setHeader("Access-Control-Allow-Methods", any())
-            response.setHeader("Access-Control-Allow-Headers", any())
-            response.setHeader("Access-Control-Max-Age", "20")
+            call.rawResponse.setHeader("Access-Control-Allow-Methods", any())
+            call.rawResponse.setHeader("Access-Control-Allow-Headers", any())
+            call.rawResponse.setHeader("Access-Control-Max-Age", any())
         }
 
         verify {
             call.status = 201
         }
+
+        confirmVerified(call.rawResponse)
     }
 
     @Test

--- a/cors/src/test/kotlin/kotlet/cors/CorsIntegration.kt
+++ b/cors/src/test/kotlin/kotlet/cors/CorsIntegration.kt
@@ -2,6 +2,7 @@ package kotlet.cors
 
 import io.mockk.confirmVerified
 import io.mockk.verify
+import kotlet.HttpCall
 import kotlet.Kotlet
 import kotlet.mocks.Mocks
 import kotlin.test.Test
@@ -98,6 +99,47 @@ class CorsIntegration {
 
         verify {
             call.rawResponse.sendError(405, "Method not allowed")
+        }
+
+        confirmVerified(call.rawResponse)
+    }
+
+    @Test
+    fun testCorsErrorOnGetMethod() {
+        val routing = Kotlet.routing {
+            installCORS(
+                object : CorsRules {
+                    override fun getResponse(call: HttpCall): CorsResponse {
+                        return CorsResponse.error(403, "Cors Error")
+                    }
+
+                }
+            )
+
+            get("/test") {
+                it.status = 202
+            }
+        }
+
+        val handler = Kotlet.handler(routing)
+
+        val call = Mocks.httpCall(
+            method = kotlet.HttpMethod.GET,
+            routePath = "/test",
+            headers = mapOf(
+                "Origin" to "https://example.com",
+                "Access-Control-Request-Method" to "GET"
+            )
+        )
+
+        handler.service(call.rawRequest, call.rawResponse)
+
+        verify {
+            call.respondError(403, "Cors Error")
+        }
+
+        verify(exactly = 0) {
+            call.rawResponse.setHeader("Access-Control-Allow-Origin", any())
         }
 
         confirmVerified(call.rawResponse)

--- a/cors/src/test/kotlin/kotlet/cors/CorsIntegration.kt
+++ b/cors/src/test/kotlin/kotlet/cors/CorsIntegration.kt
@@ -69,6 +69,7 @@ class CorsIntegration {
 
         verify {
             call.status = 202
+            call.rawResponse.setHeader("Access-Control-Allow-Origin", "*")
         }
 
         confirmVerified(call.rawResponse)


### PR DESCRIPTION
This pull request refactors the CORS interceptor logic to better distinguish between preflight and regular CORS requests, improves header management, and updates related tests to match the new behavior. The most significant changes are the introduction of clearer separation for preflight request handling, improved header writing (including the `Vary` header), and test updates to validate the new logic.

### CORS Interceptor Logic Improvements

* Refactored the `CorsInterceptor` to explicitly handle preflight (`OPTIONS`) requests by introducing a dedicated `processPreflightRequest` method, ensuring that preflight requests are processed and the call chain is aborted after handling. Regular CORS requests now only write necessary headers and continue the call chain.
* Added an `isCorsRequest` helper to check for the presence of the `Origin` header, ensuring that CORS logic only applies when appropriate.

### Header Management Enhancements

* Updated header writing logic to set the `Vary: Origin` header when the allowed origin is not a wildcard (`*`), improving cache behavior for CORS responses.
* Ensured that only relevant headers are set for non-preflight requests, and validated this behavior in the unit tests.

### Test Updates

* Updated unit tests to use the new `Mocks.httpCall` helper for more concise test setup and improved clarity.
* Added verification for the `Vary: Origin` header in preflight test cases, and confirmed that only the correct headers are set for both preflight and regular requests. [[1]](diffhunk://#diff-aa1c446c684fedd784a0fb82b0300d10fa2d534199402ef6c01da8334634f1c7R72) [[2]](diffhunk://#diff-aa1c446c684fedd784a0fb82b0300d10fa2d534199402ef6c01da8334634f1c7L116-R146) [[3]](diffhunk://#diff-ac0f62ff5fc80a933c190c08ee5a503a60c64476546d09f574c81d3352cedff2R72)