### PR TITLE
Update Kotlin version to 2.2.20 and improve path normalization logic

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.2.10" />
+    <option name="version" value="2.2.20" />
   </component>
 </project>

--- a/core/src/main/kotlin/kotlet/Routing.kt
+++ b/core/src/main/kotlin/kotlet/Routing.kt
@@ -755,10 +755,14 @@ private fun buildRoutePath(segments: Collection<String>, path: String): String {
 }
 
 private fun normalizePathSegment(segment: String): String {
-    return if (segment.startsWith(RouteHelpers.ROOT_ROUTE_PATH)) {
-        segment.replace("//", "/")
+    val normalizedSegment = segment
+        .replace("//", "/")
+        .removeSuffix("/")
+
+    return if (normalizedSegment.startsWith(RouteHelpers.ROOT_ROUTE_PATH)) {
+        normalizedSegment
     } else {
-        "/$segment".replace("//", "/")
+        "/$normalizedSegment"
     }
 }
 

--- a/core/src/test/kotlin/kotlet/RoutesMatcherUnitTest.kt
+++ b/core/src/test/kotlin/kotlet/RoutesMatcherUnitTest.kt
@@ -14,6 +14,19 @@ import kotlin.test.fail
 internal class RoutesMatcherUnitTest {
 
     @Test
+    fun findRoute_Root() {
+        // simple test – longer static path should always win
+        val routes = routing {
+            get("/") {}
+        }
+
+        routes.findMatchForShuffledRoutes(mockRequest("/")) { route, params, allRoutes ->
+            assertEquals("/", route.path, "All routes: $allRoutes")
+            assertEquals(0, params.size, "All routes: $allRoutes")
+        }
+    }
+
+    @Test
     fun findRoute_Static() {
         // simple test – longer static path should always win
         val routes = routing {

--- a/core/src/test/kotlin/kotlet/RoutesMatcherUnitTest.kt
+++ b/core/src/test/kotlin/kotlet/RoutesMatcherUnitTest.kt
@@ -249,7 +249,7 @@ internal class RoutesMatcherUnitTest {
                     put("/c") {}
                 }
 
-                route("/e") {
+                route("/e/") {
                     get {}
                     post("/h") {}
                 }


### PR DESCRIPTION
This pull request includes a version bump for the Kotlin compiler, improvements to path normalization logic in the routing core, and a corresponding test update to ensure correct route handling with trailing slashes.

Dependency update:

* Upgraded Kotlin compiler version from 2.2.10 to 2.2.20 in `.idea/kotlinc.xml` to keep the project up to date with the latest language features and fixes.

Routing improvements:

* Enhanced the `normalizePathSegment` function in `Routing.kt` to consistently remove trailing slashes from path segments and ensure normalized paths, improving route matching reliability.

Test adjustments:

* Updated the route definition in `RoutesMatcherUnitTest.kt` to use a trailing slash (`/e/` instead of `/e`), aligning test coverage with the improved path normalization logic.